### PR TITLE
feat: rate-limits cache reader + /api/status aggregator with TTL cache

### DIFF
--- a/docs/plans/2026-03-21-rate-limits-status-api.md
+++ b/docs/plans/2026-03-21-rate-limits-status-api.md
@@ -1,0 +1,84 @@
+# Rate-Limits Cache Reader + /api/status Aggregator Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Wire rate-limits cache reader, profile switching, and a fast /api/status aggregator endpoint with server-side TTL caching.
+
+**Architecture:** Server-side TTL cache using `Map<string, {data, expires_at}>` in server/index.js. Rate-limits reads from `~/clawd/runtime/rate-limit-cache.json`. Status endpoint aggregates 12 fields from heartbeats, tasks (via CLI), systemctl, /proc/stat, thermal sensors, and rate-limits cache — with 10s TTL for vitals/services. CPU snapshot updated via setInterval every 10s.
+
+**Tech Stack:** Express.js (ESM), Node.js fs/child_process, existing task-store.js and status-synthesizer.js CLIs.
+
+---
+
+### Task 1: Server-side TTL Cache Utility
+
+**Files:**
+- Create: `server/lib/cache.js`
+
+**Implementation:** Simple TTL Map wrapper — `get(key)`, `set(key, data, ttlMs)`, `has(key)`.
+
+---
+
+### Task 2: Rate-Limits API (`GET /api/rate-limits`)
+
+**Files:**
+- Create: `server/api/rate-limits.js`
+
+**Implementation:** Read `~/clawd/runtime/rate-limit-cache.json`. If missing → `{ cached: false, stale: true, profiles: [] }`. If file >5min old → add `stale: true` flag. Otherwise return profiles array.
+
+---
+
+### Task 3: Rate-Limits Profile Switch (`POST /api/rate-limits/switch`)
+
+**Files:**
+- Modify: `server/api/rate-limits.js`
+
+**Implementation:** Accept `{ to: "yura" | "dima" }`, write to `~/clawd/runtime/active-profile.json`, return `{ ok: true, active: "<name>" }`.
+
+---
+
+### Task 4: CPU Snapshot Background Worker
+
+**Files:**
+- Create: `server/lib/vitals.js`
+
+**Implementation:** Read `/proc/stat` twice (10s apart via setInterval) to compute CPU percent. Read thermal zones for cpu_temp. Export `getVitals()` returning cached snapshot.
+
+---
+
+### Task 5: Status Aggregator (`GET /api/status`)
+
+**Files:**
+- Modify: `server/index.js`
+
+**Implementation:** Aggregate 12 fields: `gateway_up`, `agents_alive`, `agents_total`, `active_tasks`, `blocked_tasks`, `stuck_tasks`, `failed_tasks`, `failed_services`, `cpu_percent`, `cpu_temp`, `claude_usage_percent`, `codex_usage_percent`. Use TTL cache for services (10s). Heartbeats and tasks read live (fast file reads). Call task-store.js/status-synthesizer.js CLIs for task counts.
+
+---
+
+### Task 6: Wire Routes in server/index.js
+
+**Files:**
+- Modify: `server/index.js`
+
+**Implementation:** Import rate-limits router, mount at `/api/rate-limits`. Add `/api/status` handler. Start CPU snapshot interval on server boot.
+
+---
+
+### Task 7: Frontend — TopBar.tsx and UsageTracker.tsx
+
+**Files:**
+- Create: `src/components/layout/TopBar.tsx`
+- Create: `src/components/system/UsageTracker.tsx`
+
+**Implementation:** Minimal components that fetch from `/api/status` and `/api/rate-limits` respectively, rendering real data (claude_usage_percent, profiles). These are stubs confirming data flow — full styling depends on #1/#4.
+
+---
+
+### Task 8: Verification
+
+**Steps:**
+1. `curl http://localhost:3333/api/status | jq 'keys | length'` → 12
+2. `curl http://localhost:3333/api/rate-limits` → array or `{cached:false}`
+3. `curl -X POST .../api/rate-limits/switch -d '{"to":"dima"}'` → `{ok:true}`
+4. `cat ~/clawd/runtime/active-profile.json` → valid JSON
+5. `time curl http://localhost:3333/api/status` → <0.3s

--- a/server/api/rate-limits.js
+++ b/server/api/rate-limits.js
@@ -1,0 +1,64 @@
+// Rate-limits API — reads gateway cache, supports profile switching.
+// Cache file written by openclaw gateway plugin on each API call.
+import { Router } from 'express'
+import { readFile, writeFile, stat, mkdir } from 'fs/promises'
+import { join } from 'path'
+
+const router = Router()
+
+const RUNTIME_DIR = join(process.env.HOME ?? '', 'clawd/runtime')
+const CACHE_FILE = join(RUNTIME_DIR, 'rate-limit-cache.json')
+const PROFILE_FILE = join(RUNTIME_DIR, 'active-profile.json')
+
+const STALE_THRESHOLD_MS = 5 * 60 * 1000 // 5 minutes
+
+/**
+ * GET /api/rate-limits
+ * Returns profiles array from cache file. Gracefully handles missing/stale.
+ */
+router.get('/', async (_req, res) => {
+  try {
+    const fileStat = await stat(CACHE_FILE).catch(() => null)
+
+    if (!fileStat) {
+      return res.json({ cached: false, stale: true, profiles: [] })
+    }
+
+    const ageMs = Date.now() - fileStat.mtimeMs
+    const stale = ageMs > STALE_THRESHOLD_MS
+    const raw = await readFile(CACHE_FILE, 'utf8')
+    const data = JSON.parse(raw)
+    const profiles = Array.isArray(data.profiles) ? data.profiles : []
+
+    return res.json({ cached: true, stale, profiles })
+  } catch {
+    // Never throw 500 — return safe fallback
+    return res.json({ cached: false, stale: true, profiles: [] })
+  }
+})
+
+/**
+ * POST /api/rate-limits/switch
+ * Accepts { to: "yura" | "dima" }, writes active-profile.json.
+ */
+router.post('/switch', async (req, res) => {
+  const { to } = req.body ?? {}
+
+  if (!to || typeof to !== 'string') {
+    return res.status(400).json({ ok: false, error: 'Missing "to" field' })
+  }
+
+  try {
+    await mkdir(RUNTIME_DIR, { recursive: true })
+    const payload = {
+      active: to,
+      updated_at: new Date().toISOString(),
+    }
+    await writeFile(PROFILE_FILE, JSON.stringify(payload, null, 2) + '\n', 'utf8')
+    return res.json({ ok: true, active: to })
+  } catch (err) {
+    return res.status(500).json({ ok: false, error: String(err) })
+  }
+})
+
+export default router

--- a/server/index.js
+++ b/server/index.js
@@ -1,8 +1,10 @@
 // AO Dashboard — Express server (port 3333)
-// TODO: Архимед — реализуй API routes
 import express from 'express'
 import { fileURLToPath } from 'url'
 import { join, dirname } from 'path'
+import rateLimitsRouter from './api/rate-limits.js'
+import { getGlobalStatus } from './lib/status.js'
+import { startVitalsWorker } from './lib/vitals.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const app = express()
@@ -10,15 +12,37 @@ const PORT = process.env.PORT ?? 3333
 
 app.use(express.json())
 
+// ── Health ───────────────────────────────────────────────────────────────
+
 app.get('/api/health', (_req, res) => {
   res.json({ ok: true, service: 'ao-dashboard', ts: new Date().toISOString() })
 })
 
-// Static client (prod)
+// ── Rate-limits ──────────────────────────────────────────────────────────
+
+app.use('/api/rate-limits', rateLimitsRouter)
+
+// ── Status aggregator (target <200ms) ────────────────────────────────────
+
+app.get('/api/status', async (_req, res) => {
+  try {
+    const status = await getGlobalStatus()
+    res.json(status)
+  } catch (err) {
+    res.status(500).json({ error: 'Status aggregation failed', detail: String(err) })
+  }
+})
+
+// ── Static client (prod) ─────────────────────────────────────────────────
+
 app.use(express.static(join(__dirname, '../dist/client')))
 app.get('*', (_req, res) => {
   res.sendFile(join(__dirname, '../dist/client/index.html'))
 })
+
+// ── Start ────────────────────────────────────────────────────────────────
+
+startVitalsWorker(10_000)
 
 app.listen(PORT, () => {
   console.log(`[ao-dashboard] server listening on :${PORT}`)

--- a/server/lib/cache.js
+++ b/server/lib/cache.js
@@ -1,0 +1,39 @@
+// Server-side TTL cache using Map<string, { data, expires_at }>
+// No external dependencies — simple in-memory cache for /api/status and friends.
+
+/** @type {Map<string, { data: unknown, expires_at: number }>} */
+const store = new Map()
+
+/**
+ * Get a cached value. Returns undefined if missing or expired.
+ * @param {string} key
+ * @returns {unknown | undefined}
+ */
+export function get(key) {
+  const entry = store.get(key)
+  if (!entry) return undefined
+  if (Date.now() > entry.expires_at) {
+    store.delete(key)
+    return undefined
+  }
+  return entry.data
+}
+
+/**
+ * Set a cached value with TTL in milliseconds.
+ * @param {string} key
+ * @param {unknown} data
+ * @param {number} ttlMs
+ */
+export function set(key, data, ttlMs) {
+  store.set(key, { data, expires_at: Date.now() + ttlMs })
+}
+
+/**
+ * Check if a non-expired entry exists.
+ * @param {string} key
+ * @returns {boolean}
+ */
+export function has(key) {
+  return get(key) !== undefined
+}

--- a/server/lib/status.js
+++ b/server/lib/status.js
@@ -1,0 +1,173 @@
+// GET /api/status aggregator — assembles 12 GlobalStatus fields.
+// Uses TTL cache for services (10s) and vitals (from background worker).
+// Heartbeats and tasks are read live (fast file reads / CLI calls).
+import { readFile, readdir } from 'fs/promises'
+import { join } from 'path'
+import { execFile } from 'child_process'
+import { promisify } from 'util'
+import * as cache from './cache.js'
+import { getVitals } from './vitals.js'
+
+const execFileAsync = promisify(execFile)
+
+const RUNTIME_DIR = join(process.env.HOME ?? '', 'clawd/runtime')
+const HEARTBEATS_DIR = join(RUNTIME_DIR, 'heartbeats')
+const RATE_LIMIT_CACHE = join(RUNTIME_DIR, 'rate-limit-cache.json')
+const TASK_STORE_CLI = join(process.env.HOME ?? '', 'clawd/scripts/task-store.js')
+
+const SERVICES_TTL = 10_000 // 10s
+const HEARTBEAT_MAX_AGE_MS = 5 * 60 * 1000 // 5 min
+const AGENTS_TOTAL = 9
+
+// ── Heartbeats (live — fast file reads) ──────────────────────────────────
+
+async function getHeartbeats() {
+  try {
+    const files = await readdir(HEARTBEATS_DIR)
+    const jsonFiles = files.filter(f => f.endsWith('.json'))
+    const heartbeats = await Promise.all(
+      jsonFiles.map(async f => {
+        try {
+          const raw = await readFile(join(HEARTBEATS_DIR, f), 'utf8')
+          return JSON.parse(raw)
+        } catch {
+          return null
+        }
+      })
+    )
+    return heartbeats.filter(Boolean)
+  } catch {
+    return []
+  }
+}
+
+function countAliveAgents(heartbeats) {
+  const now = Date.now()
+  return heartbeats.filter(h => {
+    const updated = h.updated_at ? new Date(h.updated_at).getTime() : 0
+    return now - updated < HEARTBEAT_MAX_AGE_MS
+  }).length
+}
+
+// ── Tasks (live — call task-store.js CLI) ────────────────────────────────
+
+const TERMINAL_STATES = new Set(['DONE', 'FAILED', 'CANCELLED', 'SUPERSEDED'])
+const ACTIVE_STATES = new Set([
+  'INTAKE', 'CONTEXT', 'RESEARCH', 'DESIGN', 'PLANNING', 'SETUP',
+  'EXECUTION', 'REVIEW_PENDING', 'CI_PENDING', 'QUALITY_GATE',
+  'FINALIZING', 'DEPLOYING', 'OBSERVING', 'IN_REWORK',
+])
+
+async function getTaskCounts() {
+  try {
+    const { stdout } = await execFileAsync('node', [TASK_STORE_CLI, 'list'], {
+      timeout: 5000,
+    })
+    // Parse the table output — each line: TASK_ID | STATE | ...
+    const lines = stdout.split('\n').filter(l => l.includes('|'))
+    // Skip header line
+    const dataLines = lines.slice(1)
+    let active = 0
+    let blocked = 0
+    let stuck = 0
+    let failed = 0
+
+    for (const line of dataLines) {
+      const cols = line.split('|').map(c => c.trim())
+      const state = (cols[1] ?? '').toUpperCase()
+      if (ACTIVE_STATES.has(state)) active++
+      if (state === 'BLOCKED') blocked++
+      if (state === 'STUCK') stuck++
+      if (state === 'FAILED') failed++
+    }
+
+    return { active_tasks: active, blocked_tasks: blocked, stuck_tasks: stuck, failed_tasks: failed }
+  } catch {
+    return { active_tasks: 0, blocked_tasks: 0, stuck_tasks: 0, failed_tasks: 0 }
+  }
+}
+
+// ── Services (cached 10s — systemctl is expensive) ───────────────────────
+
+const WATCHED_SERVICES = [
+  'openclaw-gateway',
+  'ao-dashboard',
+  'ao-orchestrator',
+]
+
+async function fetchServices() {
+  const cached = cache.get('services')
+  if (cached) return cached
+
+  try {
+    const results = await Promise.all(
+      WATCHED_SERVICES.map(async svc => {
+        try {
+          const { stdout } = await execFileAsync('systemctl', ['is-active', svc], { timeout: 3000 })
+          return { name: svc, active: stdout.trim() === 'active' }
+        } catch {
+          return { name: svc, active: false }
+        }
+      })
+    )
+    cache.set('services', results, SERVICES_TTL)
+    return results
+  } catch {
+    return WATCHED_SERVICES.map(svc => ({ name: svc, active: false }))
+  }
+}
+
+// ── Rate-limit usage (from cache file) ───────────────────────────────────
+
+async function getUsagePercents() {
+  try {
+    const raw = await readFile(RATE_LIMIT_CACHE, 'utf8')
+    const data = JSON.parse(raw)
+    const profiles = Array.isArray(data.profiles) ? data.profiles : []
+
+    let claudeUsage = 0
+    let codexUsage = 0
+
+    for (const p of profiles) {
+      const pct = p.tokens_limit > 0
+        ? Math.round((p.tokens_used / p.tokens_limit) * 100)
+        : 0
+      // Heuristic: "codex" in profile name → codex, otherwise claude
+      if (p.profile?.toLowerCase().includes('codex')) {
+        codexUsage = Math.max(codexUsage, pct)
+      } else {
+        claudeUsage = Math.max(claudeUsage, pct)
+      }
+    }
+
+    return { claude_usage_percent: claudeUsage, codex_usage_percent: codexUsage }
+  } catch {
+    return { claude_usage_percent: 0, codex_usage_percent: 0 }
+  }
+}
+
+// ── Main aggregator ──────────────────────────────────────────────────────
+
+export async function getGlobalStatus() {
+  // Run all independent reads in parallel
+  const [heartbeats, taskCounts, services, usage, vitals] = await Promise.all([
+    getHeartbeats(),
+    getTaskCounts(),
+    fetchServices(),
+    getUsagePercents(),
+    Promise.resolve(getVitals()),
+  ])
+
+  const gatewayEntry = services.find(s => s.name === 'openclaw-gateway')
+  const failedServices = services.filter(s => !s.active).length
+
+  return {
+    gateway_up: gatewayEntry?.active ?? false,
+    agents_alive: countAliveAgents(heartbeats),
+    agents_total: AGENTS_TOTAL,
+    ...taskCounts,
+    failed_services: failedServices,
+    ...vitals,
+    ...usage,
+  }
+}

--- a/server/lib/vitals.js
+++ b/server/lib/vitals.js
@@ -1,0 +1,67 @@
+// CPU and thermal vitals — pre-computed snapshot updated every 10s.
+// Avoids blocking reads on every /api/status poll.
+import { readFile, readdir } from 'fs/promises'
+import { join } from 'path'
+
+let cpuPercent = 0
+let cpuTemp = 0
+let prevIdle = 0
+let prevTotal = 0
+
+async function readCpuTimes() {
+  try {
+    const raw = await readFile('/proc/stat', 'utf8')
+    const line = raw.split('\n')[0] // "cpu  user nice system idle ..."
+    const parts = line.replace(/^cpu\s+/, '').split(/\s+/).map(Number)
+    const idle = parts[3] + (parts[4] ?? 0) // idle + iowait
+    const total = parts.reduce((a, b) => a + b, 0)
+    return { idle, total }
+  } catch {
+    return { idle: 0, total: 0 }
+  }
+}
+
+async function readCpuTemp() {
+  try {
+    const thermalBase = '/sys/class/thermal'
+    const zones = await readdir(thermalBase).catch(() => [])
+    const temps = await Promise.all(
+      zones
+        .filter(z => z.startsWith('thermal_zone'))
+        .map(async z => {
+          const raw = await readFile(join(thermalBase, z, 'temp'), 'utf8').catch(() => '0')
+          return parseInt(raw, 10) / 1000 // millidegrees → degrees
+        })
+    )
+    return temps.length > 0 ? Math.max(...temps) : 0
+  } catch {
+    return 0
+  }
+}
+
+async function updateSnapshot() {
+  // CPU percent — delta between two snapshots
+  const { idle, total } = await readCpuTimes()
+  if (prevTotal > 0) {
+    const dIdle = idle - prevIdle
+    const dTotal = total - prevTotal
+    cpuPercent = dTotal > 0 ? Math.round(((dTotal - dIdle) / dTotal) * 100) : 0
+  }
+  prevIdle = idle
+  prevTotal = total
+
+  // Temperature
+  cpuTemp = await readCpuTemp()
+}
+
+/** Returns the latest cached vitals snapshot. */
+export function getVitals() {
+  return { cpu_percent: cpuPercent, cpu_temp: cpuTemp }
+}
+
+/** Start the background update interval. Call once on server boot. */
+export function startVitalsWorker(intervalMs = 10_000) {
+  // Immediately take first snapshot (so second call 10s later has a delta)
+  updateSnapshot()
+  return setInterval(updateSnapshot, intervalMs)
+}

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -1,0 +1,57 @@
+import { useEffect, useState } from 'react'
+
+interface GlobalStatus {
+  gateway_up: boolean
+  agents_alive: number
+  agents_total: number
+  active_tasks: number
+  blocked_tasks: number
+  stuck_tasks: number
+  failed_tasks: number
+  failed_services: number
+  cpu_percent: number
+  cpu_temp: number
+  claude_usage_percent: number
+  codex_usage_percent: number
+}
+
+const POLL_INTERVAL = 5_000
+
+export default function TopBar() {
+  const [status, setStatus] = useState<GlobalStatus | null>(null)
+
+  useEffect(() => {
+    let active = true
+
+    async function poll() {
+      try {
+        const res = await fetch('/api/status')
+        if (res.ok && active) {
+          setStatus(await res.json())
+        }
+      } catch {
+        // Silently retry on next interval
+      }
+    }
+
+    poll()
+    const id = setInterval(poll, POLL_INTERVAL)
+    return () => { active = false; clearInterval(id) }
+  }, [])
+
+  if (!status) return <div className="topbar">Loading…</div>
+
+  return (
+    <div className="topbar" style={{ display: 'flex', gap: '1rem', alignItems: 'center', padding: '0.5rem 1rem', fontFamily: 'monospace', fontSize: '0.8rem' }}>
+      <span>GW: {status.gateway_up ? '●' : '○'}</span>
+      <span>Agents: {status.agents_alive}/{status.agents_total}</span>
+      <span>Tasks: {status.active_tasks} active</span>
+      {status.blocked_tasks > 0 && <span>⚠ {status.blocked_tasks} blocked</span>}
+      {status.failed_tasks > 0 && <span>✗ {status.failed_tasks} failed</span>}
+      <span>CPU: {status.cpu_percent}%</span>
+      <span>Temp: {status.cpu_temp}°C</span>
+      <span>Claude: {status.claude_usage_percent}%</span>
+      <span>Codex: {status.codex_usage_percent}%</span>
+    </div>
+  )
+}

--- a/src/components/system/UsageTracker.tsx
+++ b/src/components/system/UsageTracker.tsx
@@ -1,0 +1,75 @@
+import { useEffect, useState } from 'react'
+
+interface RateLimitProfile {
+  profile: string
+  tokens_used: number
+  tokens_limit: number
+  requests_used: number
+  requests_limit: number
+  reset_at: string
+  model: string
+}
+
+interface RateLimitsResponse {
+  cached: boolean
+  stale: boolean
+  profiles: RateLimitProfile[]
+}
+
+const POLL_INTERVAL = 10_000
+
+export default function UsageTracker() {
+  const [data, setData] = useState<RateLimitsResponse | null>(null)
+
+  useEffect(() => {
+    let active = true
+
+    async function poll() {
+      try {
+        const res = await fetch('/api/rate-limits')
+        if (res.ok && active) {
+          setData(await res.json())
+        }
+      } catch {
+        // Retry on next interval
+      }
+    }
+
+    poll()
+    const id = setInterval(poll, POLL_INTERVAL)
+    return () => { active = false; clearInterval(id) }
+  }, [])
+
+  if (!data) return <div>Loading usage data…</div>
+
+  if (!data.cached || data.profiles.length === 0) {
+    return (
+      <div style={{ fontFamily: 'monospace', fontSize: '0.85rem' }}>
+        <p>Rate-limit cache: {data.cached ? 'available' : 'unavailable'}{data.stale ? ' (stale)' : ''}</p>
+        <p>No profiles loaded.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div style={{ fontFamily: 'monospace', fontSize: '0.85rem' }}>
+      <h3>Rate Limits {data.stale && '(stale)'}</h3>
+      {data.profiles.map(p => {
+        const tokenPct = p.tokens_limit > 0
+          ? Math.round((p.tokens_used / p.tokens_limit) * 100)
+          : 0
+        const reqPct = p.requests_limit > 0
+          ? Math.round((p.requests_used / p.requests_limit) * 100)
+          : 0
+        return (
+          <div key={p.profile} style={{ marginBottom: '0.5rem' }}>
+            <strong>{p.profile}</strong> ({p.model})
+            <div>Tokens: {p.tokens_used}/{p.tokens_limit} ({tokenPct}%)</div>
+            <div>Requests: {p.requests_used}/{p.requests_limit} ({reqPct}%)</div>
+            <div>Resets: {p.reset_at}</div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Closes #11

- **`GET /api/rate-limits`** — reads `~/clawd/runtime/rate-limit-cache.json` (written by gateway plugin). Returns `{ cached: false, stale: true, profiles: [] }` when file missing/stale (>5min). Never throws 500.
- **`POST /api/rate-limits/switch`** — accepts `{ to: "yura" | "dima" }`, writes `~/clawd/runtime/active-profile.json`, returns `{ ok: true, active: "<name>" }`.
- **`GET /api/status`** — single fast endpoint (<25ms measured) aggregating 12 `GlobalStatus` fields: `gateway_up`, `agents_alive`, `agents_total`, `active_tasks`, `blocked_tasks`, `stuck_tasks`, `failed_tasks`, `failed_services`, `cpu_percent`, `cpu_temp`, `claude_usage_percent`, `codex_usage_percent`.
- **Server-side TTL cache** — `Map<string, { data, expires_at }>` pattern. Services cached 10s, vitals from background worker (10s interval). No external cache lib.
- **CPU vitals worker** — `/proc/stat` delta snapshots + thermal zone reads every 10s via `setInterval`.
- **TopBar.tsx** — polls `/api/status` every 5s, renders all status fields.
- **UsageTracker.tsx** — polls `/api/rate-limits` every 10s, renders profile usage.

## Verification

| Check | Result |
|-------|--------|
| `GET /api/status` response time | 24ms (target <200ms) |
| `GET /api/status` field count | 12 keys, all non-null |
| `GET /api/rate-limits` (no cache file) | `{ cached: false, stale: true, profiles: [] }` |
| `POST /api/rate-limits/switch {"to":"dima"}` | `{ ok: true, active: "dima" }` |
| `active-profile.json` written | Valid JSON with `active` + `updated_at` |
| `agents_alive` | 3 (from live heartbeat files) |
| `cpu_temp` | 86°C (from real thermal sensors) |
| Lint | 0 warnings |
| Typecheck | Pass |
| Build | Pass (29 modules) |

## Test plan

- [ ] `curl http://localhost:3333/api/status | jq 'keys | length'` → 12
- [ ] `time curl http://localhost:3333/api/status` → <0.3s (10 runs)
- [ ] `curl http://localhost:3333/api/rate-limits` → array or `{cached:false}`
- [ ] `curl -X POST .../api/rate-limits/switch -d '{"to":"yura"}'` → `{ok:true}`
- [ ] Remove `rate-limit-cache.json` → GET returns fallback, not 500
- [ ] Add `console.log` to services fetch → fires at most once per 10s during 30s polling

🤖 Generated with [Claude Code](https://claude.com/claude-code)