### PR TITLE
feat(#6): Agents page — AgentGrid + AgentCard + AgentDetail 5-tab + MailboxViewer [rebased]

### DIFF
--- a/.claude/metadata-updater.sh
+++ b/.claude/metadata-updater.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Metadata Updater Hook for Agent Orchestrator
+#
+# This PostToolUse hook automatically updates session metadata when:
+# - gh pr create: extracts PR URL and writes to metadata
+# - git checkout -b / git switch -c: extracts branch name and writes to metadata
+# - gh pr merge: updates status to "merged"
+
+set -euo pipefail
+
+# Configuration
+AO_DATA_DIR="${AO_DATA_DIR:-$HOME/.ao-sessions}"
+
+# Read hook input from stdin
+input=$(cat)
+
+# Extract fields from JSON (using jq if available, otherwise basic parsing)
+if command -v jq &>/dev/null; then
+  tool_name=$(echo "$input" | jq -r '.tool_name // empty')
+  command=$(echo "$input" | jq -r '.tool_input.command // empty')
+  output=$(echo "$input" | jq -r '.tool_response // empty')
+  exit_code=$(echo "$input" | jq -r '.exit_code // 0')
+else
+  # Fallback: basic JSON parsing without jq
+  tool_name=$(echo "$input" | grep -o '"tool_name"[[:space:]]*:[[:space:]]*"[^"]*"' | cut -d'"' -f4 || echo "")
+  command=$(echo "$input" | grep -o '"command"[[:space:]]*:[[:space:]]*"[^"]*"' | cut -d'"' -f4 || echo "")
+  output=$(echo "$input" | grep -o '"tool_response"[[:space:]]*:[[:space:]]*"[^"]*"' | cut -d'"' -f4 || echo "")
+  exit_code=$(echo "$input" | grep -o '"exit_code"[[:space:]]*:[[:space:]]*[0-9]*' | grep -o '[0-9]*$' || echo "0")
+fi
+
+# Only process successful commands (exit code 0)
+if [[ "$exit_code" -ne 0 ]]; then
+  echo '{}'
+  exit 0
+fi
+
+# Only process Bash tool calls
+if [[ "$tool_name" != "Bash" ]]; then
+  echo '{}' # Empty JSON output
+  exit 0
+fi
+
+# Validate AO_SESSION is set
+if [[ -z "${AO_SESSION:-}" ]]; then
+  echo '{"systemMessage": "AO_SESSION environment variable not set, skipping metadata update"}'
+  exit 0
+fi
+
+# Construct metadata file path
+# AO_DATA_DIR is already set to the project-specific sessions directory
+metadata_file="$AO_DATA_DIR/$AO_SESSION"
+
+# Ensure metadata file exists
+if [[ ! -f "$metadata_file" ]]; then
+  echo '{"systemMessage": "Metadata file not found: '"$metadata_file"'"}'
+  exit 0
+fi
+
+# Update a single key in metadata
+update_metadata_key() {
+  local key="$1"
+  local value="$2"
+
+  # Create temp file
+  local temp_file="${metadata_file}.tmp"
+
+  # Escape special sed characters in value (& | / \)
+  local escaped_value=$(echo "$value" | sed 's/[&|\/]/\\&/g')
+
+  # Check if key already exists
+  if grep -q "^$key=" "$metadata_file" 2>/dev/null; then
+    # Update existing key
+    sed "s|^$key=.*|$key=$escaped_value|" "$metadata_file" > "$temp_file"
+  else
+    # Append new key
+    cp "$metadata_file" "$temp_file"
+    echo "$key=$value" >> "$temp_file"
+  fi
+
+  # Atomic replace
+  mv "$temp_file" "$metadata_file"
+}
+
+# ============================================================================
+# Command Detection and Parsing
+# ============================================================================
+
+# Detect: gh pr create
+if [[ "$command" =~ ^gh[[:space:]]+pr[[:space:]]+create ]]; then
+  # Extract PR URL from output
+  pr_url=$(echo "$output" | grep -Eo 'https://github[.]com/[^/]+/[^/]+/pull/[0-9]+' | head -1)
+
+  if [[ -n "$pr_url" ]]; then
+    update_metadata_key "pr" "$pr_url"
+    update_metadata_key "status" "pr_open"
+    echo '{"systemMessage": "Updated metadata: PR created at '"$pr_url"'"}'
+    exit 0
+  fi
+fi
+
+# Detect: git checkout -b <branch> or git switch -c <branch>
+if [[ "$command" =~ ^git[[:space:]]+checkout[[:space:]]+-b[[:space:]]+([^[:space:]]+) ]] || \
+   [[ "$command" =~ ^git[[:space:]]+switch[[:space:]]+-c[[:space:]]+([^[:space:]]+) ]]; then
+  branch="${BASH_REMATCH[1]}"
+
+  if [[ -n "$branch" ]]; then
+    update_metadata_key "branch" "$branch"
+    echo '{"systemMessage": "Updated metadata: branch = '"$branch"'"}'
+    exit 0
+  fi
+fi
+
+# Detect: git checkout <branch> (without -b) or git switch <branch> (without -c)
+# Only update if the branch name looks like a feature branch (contains / or -)
+if [[ "$command" =~ ^git[[:space:]]+checkout[[:space:]]+([^[:space:]-]+[/-][^[:space:]]+) ]] || \
+   [[ "$command" =~ ^git[[:space:]]+switch[[:space:]]+([^[:space:]-]+[/-][^[:space:]]+) ]]; then
+  branch="${BASH_REMATCH[1]}"
+
+  # Avoid updating for checkout of commits/tags
+  if [[ -n "$branch" && "$branch" != "HEAD" ]]; then
+    update_metadata_key "branch" "$branch"
+    echo '{"systemMessage": "Updated metadata: branch = '"$branch"'"}'
+    exit 0
+  fi
+fi
+
+# Detect: gh pr merge
+if [[ "$command" =~ ^gh[[:space:]]+pr[[:space:]]+merge ]]; then
+  update_metadata_key "status" "merged"
+  echo '{"systemMessage": "Updated metadata: status = merged"}'
+  exit 0
+fi
+
+# No matching command, exit silently
+echo '{}'
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/home/aiadmin/ao-dashboard/.claude/metadata-updater.sh",
+            "timeout": 5000
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "express": "^4.18.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-markdown": "^10.1.0",
         "react-router-dom": "^6.30.3"
       },
       "devDependencies": {
@@ -1473,12 +1474,29 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
     },
     "node_modules/@types/express": {
       "version": "4.17.25",
@@ -1506,6 +1524,15 @@
         "@types/send": "*"
       }
     },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/http-errors": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
@@ -1513,11 +1540,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/mime": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -1534,7 +1576,6 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/qs": {
@@ -1555,7 +1596,6 @@
       "version": "18.3.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -1604,6 +1644,12 @@
         "@types/mime": "^1",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "7.18.0",
@@ -1802,7 +1848,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/@vitejs/plugin-react": {
@@ -1991,6 +2036,16 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/balanced-match": {
@@ -2201,6 +2256,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2229,6 +2294,46 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/chokidar": {
@@ -2303,6 +2408,16 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/commander": {
       "version": "4.1.1",
@@ -2424,7 +2539,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/date-fns": {
@@ -2448,7 +2562,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2460,6 +2573,19 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/deep-is": {
@@ -2478,6 +2604,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/destroy": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
@@ -2486,6 +2621,19 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/didyoumean": {
@@ -2857,6 +3005,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2935,6 +3093,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
@@ -3365,6 +3529,56 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -3452,6 +3666,12 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -3459,6 +3679,30 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-binary-path": {
@@ -3488,6 +3732,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-extglob": {
@@ -3523,6 +3777,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -3541,6 +3805,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/isexe": {
@@ -3700,6 +3976,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -3729,6 +4015,159 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/media-typer": {
@@ -3767,6 +4206,448 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -4017,6 +4898,31 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
@@ -4293,6 +5199,16 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -4401,6 +5317,33 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -4464,6 +5407,39 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/require-directory": {
@@ -4850,6 +5826,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/spawn-command": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2.tgz",
@@ -4880,6 +5866,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -4904,6 +5904,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
       }
     },
     "node_modules/sucrase": {
@@ -5106,6 +6124,26 @@
         "tree-kill": "cli.js"
       }
     },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
@@ -5192,6 +6230,93 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -5265,6 +6390,34 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/vite": {
@@ -5435,6 +6588,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "express": "^4.18.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-markdown": "^10.1.0",
     "react-router-dom": "^6.30.3"
   },
   "devDependencies": {

--- a/server/api/agents.js
+++ b/server/api/agents.js
@@ -1,0 +1,255 @@
+import { Router } from 'express'
+import { readdir, readFile, unlink, rename, mkdir } from 'fs/promises'
+import { join } from 'path'
+import { execFile } from 'child_process'
+import { existsSync } from 'fs'
+
+const router = Router()
+const HOME = process.env.HOME || '/home/aiadmin'
+
+const HEARTBEATS_DIR = join(HOME, 'clawd/runtime/heartbeats')
+const MAILBOXES_DIR = join(HOME, 'clawd/runtime/mailboxes')
+const COMM_DIR = join(HOME, '.openclaw/shared-memory/communication')
+const SESSIONS_SEND = join(HOME, 'clawd/scripts/sessions-send.js')
+const WEBHOOKS_FILE = join(HOME, 'clawd/runtime/agent-webhooks.json')
+
+const AGENT_META = [
+  { id: 'sokrat',           name: 'Сократ',           emoji: '🦉', role: 'Orchestrator' },
+  { id: 'archimedes',       name: 'Архимед',          emoji: '🔧', role: 'Engineer' },
+  { id: 'aristotle',        name: 'Аристотель',       emoji: '📚', role: 'Researcher' },
+  { id: 'herodotus',        name: 'Геродот',          emoji: '📜', role: 'Chronicler' },
+  { id: 'platon',           name: 'Платон',           emoji: '🏛️', role: 'Architect' },
+  { id: 'hephaestus',       name: 'Гефест',           emoji: '⚒️', role: 'Infrastructure' },
+  { id: 'brainstorm-claude', name: 'Brainstorm Claude', emoji: '🧠', role: 'Brainstorm' },
+  { id: 'brainstorm-codex', name: 'Brainstorm Codex',  emoji: '💡', role: 'Brainstorm' },
+  { id: 'leo',              name: 'Лео',              emoji: '🎨', role: 'Designer' },
+]
+
+const VALID_FOLDERS = ['inbox', 'processing', 'done', 'deadletter']
+
+async function safeReadJson(filePath) {
+  try {
+    const raw = await readFile(filePath, 'utf-8')
+    return JSON.parse(raw)
+  } catch {
+    return null
+  }
+}
+
+async function countFiles(dirPath) {
+  try {
+    const files = await readdir(dirPath)
+    return files.filter(f => f.endsWith('.json')).length
+  } catch {
+    return 0
+  }
+}
+
+function deriveStatus(heartbeat) {
+  if (!heartbeat) return 'unknown'
+  const state = heartbeat.state
+  if (state === 'active' || state === 'working' || state === 'running') return 'active'
+  if (state === 'idle') return 'idle'
+  if (state === 'waiting') return 'waiting'
+  if (state === 'dead' || state === 'error') return 'dead'
+
+  // Check age — if no heartbeat for 10+ minutes, consider dead
+  if (heartbeat.updated_at) {
+    const age = Date.now() - new Date(heartbeat.updated_at).getTime()
+    if (age > 10 * 60 * 1000) return 'idle'
+  }
+  return 'idle'
+}
+
+// GET /api/agents — list all agents with heartbeat + mailbox counts
+router.get('/', async (_req, res) => {
+  try {
+    const agents = await Promise.all(
+      AGENT_META.map(async (meta) => {
+        const heartbeat = await safeReadJson(join(HEARTBEATS_DIR, `${meta.id}.json`))
+        const mailbox = {
+          inbox:      await countFiles(join(MAILBOXES_DIR, meta.id, 'inbox')),
+          processing: await countFiles(join(MAILBOXES_DIR, meta.id, 'processing')),
+          done:       await countFiles(join(MAILBOXES_DIR, meta.id, 'done')),
+          deadletter: await countFiles(join(MAILBOXES_DIR, meta.id, 'deadletter')),
+        }
+
+        return {
+          id: meta.id,
+          name: meta.name,
+          emoji: meta.emoji,
+          role: meta.role,
+          status: deriveStatus(heartbeat),
+          current_task_id: heartbeat?.current_task_id ?? null,
+          current_step: heartbeat?.current_step ?? null,
+          progress_note: heartbeat?.progress_note ?? null,
+          checkpoint_safe: heartbeat?.checkpoint_safe ?? null,
+          last_seen: heartbeat?.updated_at ?? null,
+          mailbox,
+        }
+      })
+    )
+    res.json(agents)
+  } catch (err) {
+    res.status(500).json({ error: err.message })
+  }
+})
+
+// GET /api/agents/:id/mailbox/:folder — list envelopes in folder
+router.get('/:id/mailbox/:folder', async (req, res) => {
+  const { id, folder } = req.params
+  if (!VALID_FOLDERS.includes(folder)) {
+    return res.status(400).json({ error: `Invalid folder: ${folder}` })
+  }
+
+  const dir = join(MAILBOXES_DIR, id, folder)
+  try {
+    const files = await readdir(dir).catch(() => [])
+    const envelopes = await Promise.all(
+      files.filter(f => f.endsWith('.json')).map(async (file) => {
+        const data = await safeReadJson(join(dir, file))
+        if (!data) return null
+        return {
+          id: file.replace('.json', ''),
+          from: data.from ?? 'unknown',
+          type: data.type ?? 'unknown',
+          subject: data.subject ?? data.title ?? '(no subject)',
+          priority: data.priority ?? 'P2',
+          created_at: data.created_at ?? data.timestamp ?? '',
+          expires_at: data.expires_at ?? null,
+          payload: data.payload ?? data.body ?? null,
+        }
+      })
+    )
+    res.json(envelopes.filter(Boolean))
+  } catch (err) {
+    res.status(500).json({ error: err.message })
+  }
+})
+
+// GET /api/agents/:id/inbox-md — INBOX.md rendered content
+router.get('/:id/inbox-md', async (req, res) => {
+  const { id } = req.params
+  const filePath = join(COMM_DIR, `inbox_${id}.md`)
+  try {
+    const content = await readFile(filePath, 'utf-8')
+    res.json({ content })
+  } catch {
+    res.json({ content: '' })
+  }
+})
+
+// GET /api/agents/:id/log — communication log
+router.get('/:id/log', async (req, res) => {
+  const { id } = req.params
+  const filePath = join(COMM_DIR, `log_${id}.md`)
+  try {
+    const content = await readFile(filePath, 'utf-8')
+    res.json({ content })
+  } catch {
+    res.json({ content: '' })
+  }
+})
+
+// POST /api/agents/:id/message — send message via sessions-send.js
+router.post('/:id/message', async (req, res) => {
+  const { id } = req.params
+  const { message } = req.body
+
+  if (!message || typeof message !== 'string') {
+    return res.status(400).json({ ok: false, error: 'message is required' })
+  }
+
+  if (!existsSync(SESSIONS_SEND)) {
+    return res.status(501).json({ ok: false, error: 'sessions-send.js not found' })
+  }
+
+  try {
+    await new Promise((resolve, reject) => {
+      execFile('node', [SESSIONS_SEND, id, message], { timeout: 30000 }, (err, stdout, stderr) => {
+        if (err) reject(new Error(stderr || err.message))
+        else resolve(stdout)
+      })
+    })
+    res.json({ ok: true })
+  } catch (err) {
+    res.json({ ok: false, error: err.message })
+  }
+})
+
+// POST /api/agents/:id/wake — wake agent via webhook
+router.post('/:id/wake', async (req, res) => {
+  const { id } = req.params
+
+  try {
+    let webhooks = null
+    if (existsSync(WEBHOOKS_FILE)) {
+      webhooks = await safeReadJson(WEBHOOKS_FILE)
+    }
+
+    const url = webhooks?.[id] ?? process.env[`AGENT_WAKE_${id.toUpperCase().replace(/-/g, '_')}`]
+    if (!url) {
+      return res.status(501).json({ ok: false, error: `No wake webhook configured for ${id}` })
+    }
+
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ agent: id, action: 'wake' }),
+    })
+
+    if (!response.ok) {
+      return res.json({ ok: false, error: `Webhook returned ${response.status}` })
+    }
+
+    res.json({ ok: true })
+  } catch (err) {
+    res.json({ ok: false, error: err.message })
+  }
+})
+
+// DELETE /api/agents/:id/mailbox/:folder/:envelopeId — delete envelope
+router.delete('/:id/mailbox/:folder/:envelopeId', async (req, res) => {
+  const { id, folder, envelopeId } = req.params
+  if (!VALID_FOLDERS.includes(folder)) {
+    return res.status(400).json({ ok: false, error: `Invalid folder: ${folder}` })
+  }
+
+  const filePath = join(MAILBOXES_DIR, id, folder, `${envelopeId}.json`)
+  try {
+    await unlink(filePath)
+    res.json({ ok: true })
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      return res.status(404).json({ ok: false, error: 'Envelope not found' })
+    }
+    res.status(500).json({ ok: false, error: err.message })
+  }
+})
+
+// POST /api/agents/:id/mailbox/:folder/:envelopeId/move — move envelope to another folder
+router.post('/:id/mailbox/:folder/:envelopeId/move', async (req, res) => {
+  const { id, folder, envelopeId } = req.params
+  const { to } = req.body
+
+  if (!VALID_FOLDERS.includes(folder) || !VALID_FOLDERS.includes(to)) {
+    return res.status(400).json({ ok: false, error: 'Invalid folder' })
+  }
+
+  const src = join(MAILBOXES_DIR, id, folder, `${envelopeId}.json`)
+  const destDir = join(MAILBOXES_DIR, id, to)
+  const dest = join(destDir, `${envelopeId}.json`)
+
+  try {
+    await mkdir(destDir, { recursive: true })
+    await rename(src, dest)
+    res.json({ ok: true })
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      return res.status(404).json({ ok: false, error: 'Envelope not found' })
+    }
+    res.status(500).json({ ok: false, error: err.message })
+  }
+})
+
+export default router

--- a/server/index.js
+++ b/server/index.js
@@ -6,6 +6,7 @@ import { join, dirname } from 'path'
 import tasksRouter from './api/tasks.js'
 import statusRouter from './api/status.js'
 import rateLimitsRouter from './api/rate-limits.js'
+import agentsRouter from './api/agents.js'
 import { getGlobalStatus } from './lib/status.js'
 import { startVitalsWorker } from './lib/vitals.js'
 
@@ -32,6 +33,7 @@ app.use('/api/status', statusRouter)
 // ── Rate-limits ──────────────────────────────────────────────────────────
 
 app.use('/api/rate-limits', rateLimitsRouter)
+app.use('/api/agents', agentsRouter)
 
 // ── Global status aggregator (TTL-cached, <200ms target) ─────────────────
 

--- a/src/components/agents/AgentCard.tsx
+++ b/src/components/agents/AgentCard.tsx
@@ -1,0 +1,90 @@
+import type { AgentInfo } from '../../lib/api'
+
+function relativeTime(isoString: string | null): string {
+  if (!isoString) return 'No heartbeat'
+  const diff = Date.now() - new Date(isoString).getTime()
+  const seconds = Math.floor(diff / 1000)
+  if (seconds < 60) return `${seconds}s ago`
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  return `${days}d ago`
+}
+
+const STATUS_STYLES: Record<string, { dot: string; ring: string; animation?: string }> = {
+  active:  { dot: 'bg-status-active', ring: 'ring-status-active/30', animation: 'animate-pulse-active' },
+  idle:    { dot: 'bg-status-idle',   ring: 'ring-status-idle/20' },
+  dead:    { dot: 'bg-status-critical', ring: 'ring-status-critical/30', animation: 'animate-pulse-critical' },
+  waiting: { dot: 'bg-accent-purple', ring: 'ring-accent-purple/30' },
+  unknown: { dot: 'bg-text-disabled', ring: 'ring-text-disabled/20' },
+}
+
+interface AgentCardProps {
+  agent: AgentInfo
+  onClick: () => void
+}
+
+export default function AgentCard({ agent, onClick }: AgentCardProps) {
+  const style = STATUS_STYLES[agent.status] ?? STATUS_STYLES.unknown
+
+  return (
+    <button
+      onClick={onClick}
+      className="w-full text-left bg-bg-surface border border-border-default rounded-md p-3 hover:bg-bg-elevated transition-colors duration-100 focus:outline-none focus:ring-1 focus:ring-accent-amber/40"
+    >
+      <div className="flex items-start gap-3">
+        <span className="text-[32px] leading-none shrink-0">{agent.emoji}</span>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span className="font-medium text-text-primary truncate">{agent.name}</span>
+            <span className={`w-2 h-2 rounded-full shrink-0 ring-2 ${style.dot} ${style.ring} ${style.animation ?? ''}`} />
+          </div>
+          <div className="text-[11px] text-text-tertiary mt-0.5">{agent.role}</div>
+
+          <div className="mt-2 space-y-1">
+            <div className="text-[11px] font-mono text-text-secondary">
+              {agent.last_seen
+                ? relativeTime(agent.last_seen)
+                : 'No heartbeat — status unknown'}
+            </div>
+
+            {agent.current_task_id && (
+              <div className="text-[11px] font-mono text-text-tertiary truncate">
+                {agent.current_task_id}
+              </div>
+            )}
+
+            {agent.current_step && (
+              <div className="text-[11px] text-text-secondary truncate">
+                {agent.current_step}
+              </div>
+            )}
+
+            <div className="flex items-center gap-1 mt-1">
+              <span className="text-[11px] text-text-tertiary">
+                {agent.checkpoint_safe === true ? '\u2705' : agent.checkpoint_safe === false ? '\u274C' : '\u2014'}
+              </span>
+            </div>
+          </div>
+
+          <div className="flex gap-1.5 mt-2">
+            <MailBadge label="in" count={agent.mailbox.inbox} color="bg-accent-blue/20 text-accent-blue" />
+            <MailBadge label="proc" count={agent.mailbox.processing} color="bg-accent-amber-subtle text-accent-amber" />
+            <MailBadge label="done" count={agent.mailbox.done} color="bg-accent-emerald-subtle text-accent-emerald" />
+            <MailBadge label="dead" count={agent.mailbox.deadletter} color="bg-accent-red-subtle text-accent-red" />
+          </div>
+        </div>
+      </div>
+    </button>
+  )
+}
+
+function MailBadge({ label, count, color }: { label: string; count: number; color: string }) {
+  return (
+    <span className={`inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded text-[10px] font-mono ${color}`}>
+      {label}:{count}
+    </span>
+  )
+}

--- a/src/components/agents/AgentDetail.tsx
+++ b/src/components/agents/AgentDetail.tsx
@@ -1,0 +1,255 @@
+import { useState, useEffect, useCallback } from 'react'
+import ReactMarkdown from 'react-markdown'
+import type { AgentInfo } from '../../lib/api'
+import { fetchAgentInboxMd, fetchAgentLog, fetchAgentEvents, sendAgentMessage, wakeAgent } from '../../lib/api'
+import MailboxViewer from './MailboxViewer'
+
+const TABS = ['Mailbox', 'INBOX.md', 'Comm Log', 'Events', 'Info'] as const
+
+interface AgentDetailProps {
+  agent: AgentInfo
+  onClose: () => void
+  onToast: (message: string) => void
+}
+
+export default function AgentDetail({ agent, onClose, onToast }: AgentDetailProps) {
+  const [tab, setTab] = useState<string>('Mailbox')
+  const [messageText, setMessageText] = useState('')
+  const [sending, setSending] = useState(false)
+
+  const handleSendMessage = async () => {
+    if (!messageText.trim()) return
+    setSending(true)
+    try {
+      const result = await sendAgentMessage(agent.id, messageText.trim())
+      if (result.ok) {
+        onToast('Message sent')
+        setMessageText('')
+      } else {
+        onToast(`Send failed: ${result.error}`)
+      }
+    } catch {
+      onToast('Send failed')
+    } finally {
+      setSending(false)
+    }
+  }
+
+  const handleWake = async () => {
+    try {
+      const result = await wakeAgent(agent.id)
+      if (result.ok) {
+        onToast(`${agent.name} woken`)
+      } else {
+        onToast(`Wake failed: ${result.error}`)
+      }
+    } catch {
+      onToast('Wake failed')
+    }
+  }
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div className="fixed inset-0 bg-black/40 z-40" onClick={onClose} />
+
+      {/* Panel */}
+      <div className="fixed top-0 right-0 h-full w-[420px] max-w-full bg-bg-elevated border-l border-border-subtle z-50 flex flex-col animate-slide-in-right shadow-lg">
+        {/* Header */}
+        <div className="flex items-center gap-3 px-4 py-3 border-b border-border-subtle shrink-0">
+          <span className="text-2xl">{agent.emoji}</span>
+          <div className="flex-1 min-w-0">
+            <div className="font-medium text-text-primary">{agent.name}</div>
+            <div className="text-[11px] text-text-tertiary">{agent.role} · {agent.status}</div>
+          </div>
+          <button
+            onClick={onClose}
+            className="text-text-tertiary hover:text-text-primary transition-colors text-lg px-1"
+          >
+            &times;
+          </button>
+        </div>
+
+        {/* Actions */}
+        <div className="flex items-center gap-2 px-4 py-2 border-b border-border-subtle shrink-0">
+          <input
+            type="text"
+            value={messageText}
+            onChange={e => setMessageText(e.target.value)}
+            onKeyDown={e => { if (e.key === 'Enter') handleSendMessage() }}
+            placeholder="Send message..."
+            className="flex-1 bg-bg-void border border-border-default rounded px-2 py-1 text-[12px] font-mono text-text-primary placeholder:text-text-disabled focus:outline-none focus:border-accent-amber"
+          />
+          <button
+            onClick={handleSendMessage}
+            disabled={sending || !messageText.trim()}
+            className="px-3 py-1 rounded text-[11px] font-semibold bg-accent-amber text-text-inverse hover:bg-accent-amber/90 disabled:opacity-40 transition-colors"
+          >
+            Send
+          </button>
+          <button
+            onClick={handleWake}
+            className="px-3 py-1 rounded text-[11px] border border-border-subtle text-text-secondary hover:bg-bg-hover transition-colors"
+          >
+            Wake
+          </button>
+        </div>
+
+        {/* Tabs */}
+        <div className="flex gap-1 px-4 py-2 border-b border-border-subtle shrink-0 overflow-x-auto">
+          {TABS.map(t => (
+            <button
+              key={t}
+              onClick={() => setTab(t)}
+              className={`px-2 py-1 rounded text-[11px] whitespace-nowrap transition-colors ${
+                tab === t
+                  ? 'bg-accent-amber-subtle text-accent-amber'
+                  : 'text-text-tertiary hover:text-text-secondary hover:bg-bg-hover'
+              }`}
+            >
+              {t}
+            </button>
+          ))}
+        </div>
+
+        {/* Tab content */}
+        <div className="flex-1 overflow-y-auto scrollbar-thin p-4">
+          {tab === 'Mailbox' && (
+            <MailboxViewer agentId={agent.id} onToast={onToast} />
+          )}
+          {tab === 'INBOX.md' && (
+            <InboxMdTab agentId={agent.id} />
+          )}
+          {tab === 'Comm Log' && (
+            <CommLogTab agentId={agent.id} />
+          )}
+          {tab === 'Events' && (
+            <EventsTab agentId={agent.id} />
+          )}
+          {tab === 'Info' && (
+            <InfoTab agent={agent} />
+          )}
+        </div>
+      </div>
+    </>
+  )
+}
+
+function InboxMdTab({ agentId }: { agentId: string }) {
+  const [content, setContent] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    try {
+      const md = await fetchAgentInboxMd(agentId)
+      setContent(md)
+    } catch {
+      setContent('')
+    }
+  }, [agentId])
+
+  useEffect(() => { load() }, [load])
+
+  if (content === null) return <Loading />
+
+  if (!content) {
+    return <div className="text-[12px] text-text-tertiary py-8 text-center">No INBOX.md found</div>
+  }
+
+  return (
+    <div className="prose prose-invert prose-sm max-w-none text-[12px] text-text-secondary [&_h1]:text-text-primary [&_h2]:text-text-primary [&_h3]:text-text-primary [&_a]:text-accent-blue [&_code]:text-accent-amber [&_code]:bg-bg-surface [&_code]:px-1 [&_code]:rounded [&_pre]:bg-bg-void [&_pre]:border [&_pre]:border-border-subtle [&_pre]:rounded">
+      <ReactMarkdown>{content}</ReactMarkdown>
+    </div>
+  )
+}
+
+function CommLogTab({ agentId }: { agentId: string }) {
+  const [content, setContent] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    try {
+      const md = await fetchAgentLog(agentId)
+      setContent(md)
+    } catch {
+      setContent('')
+    }
+  }, [agentId])
+
+  useEffect(() => { load() }, [load])
+
+  if (content === null) return <Loading />
+
+  if (!content) {
+    return <div className="text-[12px] text-text-tertiary py-8 text-center">No communication log</div>
+  }
+
+  return (
+    <div className="prose prose-invert prose-sm max-w-none text-[12px] text-text-secondary [&_h1]:text-text-primary [&_h2]:text-text-primary [&_h3]:text-text-primary [&_a]:text-accent-blue [&_code]:text-accent-amber [&_code]:bg-bg-surface [&_code]:px-1 [&_code]:rounded [&_pre]:bg-bg-void [&_pre]:border [&_pre]:border-border-subtle [&_pre]:rounded">
+      <ReactMarkdown>{content}</ReactMarkdown>
+    </div>
+  )
+}
+
+function EventsTab({ agentId }: { agentId: string }) {
+  const [events, setEvents] = useState<unknown[] | null>(null)
+
+  const load = useCallback(async () => {
+    try {
+      const data = await fetchAgentEvents(agentId)
+      setEvents(data)
+    } catch {
+      setEvents([])
+    }
+  }, [agentId])
+
+  useEffect(() => { load() }, [load])
+
+  if (events === null) return <Loading />
+
+  if (events.length === 0) {
+    return <div className="text-[12px] text-text-tertiary py-8 text-center">No events</div>
+  }
+
+  return (
+    <div className="space-y-2">
+      {events.map((event, i) => (
+        <div key={i} className="bg-bg-surface border border-border-subtle rounded p-2 text-[11px] font-mono text-text-secondary">
+          <pre className="whitespace-pre-wrap">{JSON.stringify(event, null, 2)}</pre>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function InfoTab({ agent }: { agent: AgentInfo }) {
+  return (
+    <div className="space-y-3">
+      <InfoRow label="Agent ID" value={agent.id} />
+      <InfoRow label="Name" value={agent.name} />
+      <InfoRow label="Role" value={agent.role} />
+      <InfoRow label="Status" value={agent.status} />
+      <InfoRow label="Task ID" value={agent.current_task_id ?? 'none'} />
+      <InfoRow label="Current Step" value={agent.current_step ?? 'none'} />
+      <InfoRow label="Progress" value={agent.progress_note ?? 'none'} />
+      <InfoRow label="Checkpoint Safe" value={agent.checkpoint_safe === null ? 'unknown' : agent.checkpoint_safe ? 'yes' : 'no'} />
+      <InfoRow label="Last Seen" value={agent.last_seen ?? 'never'} />
+      <div className="pt-2 border-t border-border-subtle">
+        <div className="text-[10px] text-text-disabled mb-1">Heartbeat paths</div>
+        <div className="text-[11px] font-mono text-text-tertiary">~/clawd/runtime/heartbeats/{agent.id}.json</div>
+        <div className="text-[11px] font-mono text-text-tertiary">~/clawd/runtime/mailboxes/{agent.id}/</div>
+      </div>
+    </div>
+  )
+}
+
+function InfoRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-start gap-3">
+      <span className="text-[11px] text-text-tertiary w-28 shrink-0">{label}</span>
+      <span className="text-[12px] font-mono text-text-secondary break-all">{value}</span>
+    </div>
+  )
+}
+
+function Loading() {
+  return <div className="text-[11px] text-text-tertiary py-4 text-center">Loading...</div>
+}

--- a/src/components/agents/AgentGrid.tsx
+++ b/src/components/agents/AgentGrid.tsx
@@ -1,0 +1,52 @@
+import { useState, useEffect, useCallback } from 'react'
+import type { AgentInfo } from '../../lib/api'
+import { fetchAgents } from '../../lib/api'
+import AgentCard from './AgentCard'
+
+interface AgentGridProps {
+  onSelectAgent: (agent: AgentInfo) => void
+}
+
+export default function AgentGrid({ onSelectAgent }: AgentGridProps) {
+  const [agents, setAgents] = useState<AgentInfo[]>([])
+  const [error, setError] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    try {
+      const data = await fetchAgents()
+      setAgents(data)
+      setError(null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load agents')
+    }
+  }, [])
+
+  useEffect(() => {
+    load()
+    const interval = setInterval(load, 5000)
+    return () => clearInterval(interval)
+  }, [load])
+
+  if (error && agents.length === 0) {
+    return (
+      <div className="text-center py-12 text-text-secondary">
+        <p className="text-accent-red">{error}</p>
+        <button onClick={load} className="mt-2 text-[11px] text-accent-amber hover:underline">
+          Retry
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+      {agents.map(agent => (
+        <AgentCard
+          key={agent.id}
+          agent={agent}
+          onClick={() => onSelectAgent(agent)}
+        />
+      ))}
+    </div>
+  )
+}

--- a/src/components/agents/MailboxViewer.tsx
+++ b/src/components/agents/MailboxViewer.tsx
@@ -1,0 +1,131 @@
+import { useState, useEffect, useCallback } from 'react'
+import type { Envelope } from '../../lib/api'
+import { fetchAgentMailbox, deleteEnvelope, moveEnvelope } from '../../lib/api'
+
+const FOLDERS = ['inbox', 'processing', 'done', 'deadletter'] as const
+
+interface MailboxViewerProps {
+  agentId: string
+  onToast: (message: string) => void
+}
+
+export default function MailboxViewer({ agentId, onToast }: MailboxViewerProps) {
+  const [folder, setFolder] = useState<string>('inbox')
+  const [envelopes, setEnvelopes] = useState<Envelope[]>([])
+  const [loading, setLoading] = useState(false)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    try {
+      const data = await fetchAgentMailbox(agentId, folder)
+      setEnvelopes(data)
+    } catch {
+      setEnvelopes([])
+    } finally {
+      setLoading(false)
+    }
+  }, [agentId, folder])
+
+  useEffect(() => { load() }, [load])
+
+  const handleDelete = async (envId: string) => {
+    const result = await deleteEnvelope(agentId, folder, envId)
+    if (result.ok) {
+      onToast('Envelope deleted')
+      load()
+    } else {
+      onToast(`Delete failed: ${result.error}`)
+    }
+  }
+
+  const handleRetry = async (envId: string) => {
+    const result = await moveEnvelope(agentId, folder, 'inbox', envId)
+    if (result.ok) {
+      onToast('Moved to inbox')
+      load()
+    } else {
+      onToast(`Move failed: ${result.error}`)
+    }
+  }
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex gap-1 border-b border-border-subtle pb-2 mb-3">
+        {FOLDERS.map(f => (
+          <button
+            key={f}
+            onClick={() => setFolder(f)}
+            className={`px-2 py-1 rounded text-[11px] font-mono transition-colors ${
+              folder === f
+                ? 'bg-accent-amber-subtle text-accent-amber'
+                : 'text-text-tertiary hover:text-text-secondary hover:bg-bg-hover'
+            }`}
+          >
+            {f}
+          </button>
+        ))}
+      </div>
+
+      {loading ? (
+        <div className="text-[11px] text-text-tertiary py-4 text-center">Loading...</div>
+      ) : envelopes.length === 0 ? (
+        <div className="text-[12px] text-text-tertiary py-8 text-center">
+          No messages in {folder}
+        </div>
+      ) : (
+        <div className="flex-1 overflow-y-auto scrollbar-thin space-y-2">
+          {envelopes.map(env => (
+            <div key={env.id} className="bg-bg-surface border border-border-subtle rounded p-2.5">
+              <div className="flex items-start justify-between gap-2">
+                <div className="min-w-0 flex-1">
+                  <div className="text-[12px] font-medium text-text-primary truncate">
+                    {env.subject}
+                  </div>
+                  <div className="flex items-center gap-2 mt-0.5">
+                    <span className="text-[10px] text-text-tertiary">from: {env.from}</span>
+                    <span className="text-[10px] text-text-tertiary">type: {env.type}</span>
+                    <PriorityBadge priority={env.priority} />
+                  </div>
+                  <div className="text-[10px] text-text-disabled mt-1 font-mono">
+                    {env.created_at}
+                    {env.expires_at && ` · expires: ${env.expires_at}`}
+                  </div>
+                </div>
+                <div className="flex gap-1 shrink-0">
+                  {folder === 'deadletter' && (
+                    <button
+                      onClick={() => handleRetry(env.id)}
+                      className="px-2 py-0.5 text-[10px] rounded bg-accent-amber-subtle text-accent-amber hover:bg-accent-amber/20 transition-colors"
+                    >
+                      Retry
+                    </button>
+                  )}
+                  <button
+                    onClick={() => handleDelete(env.id)}
+                    className="px-2 py-0.5 text-[10px] rounded bg-accent-red-subtle text-accent-red hover:bg-accent-red/20 transition-colors"
+                  >
+                    Delete
+                  </button>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function PriorityBadge({ priority }: { priority: string }) {
+  const colors: Record<string, string> = {
+    P0: 'bg-accent-red-subtle text-accent-red',
+    P1: 'bg-accent-amber-subtle text-accent-amber',
+    P2: 'bg-accent-blue-subtle text-accent-blue',
+    P3: 'bg-bg-hover text-text-tertiary',
+  }
+  return (
+    <span className={`px-1 py-0 rounded text-[9px] font-mono ${colors[priority] ?? colors.P2}`}>
+      {priority}
+    </span>
+  )
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -153,3 +153,81 @@ export function createTask(data: {
     body: JSON.stringify(data),
   });
 }
+
+// ─── Agents ───────────────────────────────────────────────────────────────────
+
+export interface AgentInfo {
+  id: string;
+  name: string;
+  emoji: string;
+  role: string;
+  status: 'active' | 'idle' | 'dead' | 'waiting' | 'unknown';
+  current_task_id: string | null;
+  current_step: string | null;
+  progress_note: string | null;
+  checkpoint_safe: boolean | null;
+  last_seen: string | null;
+  session_key: string | null;
+  workspace_path: string | null;
+  topic_id: number | null;
+  heartbeat_raw: Record<string, unknown> | null;
+  mailbox: { inbox: number; processing: number; done: number; deadletter: number };
+}
+
+export interface Envelope {
+  id: string; from: string; type: string; subject: string; priority: string;
+  created_at: string; expires_at: string | null; payload?: unknown;
+}
+
+export interface AgentEvent {
+  event_id?: string; event_type?: string; task_id?: string;
+  actor?: string; timestamp?: string; [key: string]: unknown;
+}
+
+export async function fetchAgents(): Promise<AgentInfo[]> {
+  const res = await fetch(`${BASE}/agents`);
+  if (!res.ok) throw new Error(`Failed to fetch agents: ${res.status}`);
+  return res.json();
+}
+export async function fetchAgentMailbox(agentId: string, folder: string): Promise<Envelope[]> {
+  const res = await fetch(`${BASE}/agents/${agentId}/mailbox/${folder}`);
+  if (!res.ok) throw new Error(`Failed to fetch mailbox: ${res.status}`);
+  return res.json();
+}
+export async function fetchAgentInboxMd(agentId: string): Promise<string> {
+  const res = await fetch(`${BASE}/agents/${agentId}/inbox-md`);
+  if (!res.ok) throw new Error(`Failed to fetch inbox md: ${res.status}`);
+  return (await res.json()).content;
+}
+export async function fetchAgentLog(agentId: string): Promise<string> {
+  const res = await fetch(`${BASE}/agents/${agentId}/log`);
+  if (!res.ok) throw new Error(`Failed to fetch log: ${res.status}`);
+  return (await res.json()).content;
+}
+export async function fetchAgentEvents(agentId: string): Promise<AgentEvent[]> {
+  const res = await fetch(`${BASE}/events?agent=${agentId}`);
+  if (!res.ok) throw new Error(`Failed to fetch events: ${res.status}`);
+  return res.json();
+}
+export async function sendAgentMessage(agentId: string, message: string): Promise<{ ok: boolean; error?: string }> {
+  const res = await fetch(`${BASE}/agents/${agentId}/message`, {
+    method: 'POST', headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ message }),
+  });
+  return res.json();
+}
+export async function wakeAgent(agentId: string): Promise<{ ok: boolean; error?: string }> {
+  const res = await fetch(`${BASE}/agents/${agentId}/wake`, { method: 'POST' });
+  return res.json();
+}
+export async function deleteEnvelope(agentId: string, folder: string, envelopeId: string): Promise<{ ok: boolean; error?: string }> {
+  const res = await fetch(`${BASE}/agents/${agentId}/mailbox/${folder}/${envelopeId}`, { method: 'DELETE' });
+  return res.json();
+}
+export async function moveEnvelope(agentId: string, fromFolder: string, toFolder: string, envelopeId: string): Promise<{ ok: boolean; error?: string }> {
+  const res = await fetch(`${BASE}/agents/${agentId}/mailbox/${fromFolder}/${envelopeId}/move`, {
+    method: 'POST', headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ to: toFolder }),
+  });
+  return res.json();
+}

--- a/src/pages/AgentsPage.tsx
+++ b/src/pages/AgentsPage.tsx
@@ -1,8 +1,34 @@
+import { useState } from 'react'
+import type { AgentInfo } from '../lib/api'
+import AgentGrid from '../components/agents/AgentGrid'
+import AgentDetail from '../components/agents/AgentDetail'
+
 export default function AgentsPage() {
+  const [selectedAgent, setSelectedAgent] = useState<AgentInfo | null>(null)
+  const [toast, setToast] = useState<string | null>(null)
+
   return (
-    <div>
-      <h1 className="text-xl font-bold mb-4">Agent Command Center</h1>
-      <p className="text-text-secondary">Agents view — awaiting implementation.</p>
+    <div className="h-full flex gap-4 relative">
+      {toast && (
+        <div className="fixed top-4 right-4 z-50 bg-bg-elevated border border-border-default rounded-md px-3 py-2 text-sm text-text-primary font-mono shadow-lg">
+          {toast}
+        </div>
+      )}
+      <div className={selectedAgent ? 'w-80 shrink-0' : 'flex-1'}>
+        <div className="mb-4 flex items-center justify-between">
+          <h1 className="text-lg font-semibold text-text-primary">Agent Command Center</h1>
+        </div>
+        <AgentGrid onSelectAgent={setSelectedAgent} />
+      </div>
+      {selectedAgent && (
+        <div className="flex-1 min-w-0">
+          <AgentDetail
+            agent={selectedAgent}
+            onClose={() => setSelectedAgent(null)}
+            onToast={(msg) => { setToast(msg); setTimeout(() => setToast(null), 3000) }}
+          />
+        </div>
+      )}
     </div>
   )
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -37,6 +37,12 @@ export default {
         blue:          '#60A5FA',
         'blue-dim':    '#1E3A5F',
         'blue-subtle': 'rgba(96,165,250,0.12)',
+        accent: {
+          purple:         '#A78BFA',
+          'purple-dim':   '#4C1D95',
+          'purple-subtle':'rgba(167,139,250,0.12)',
+          amber:          '#F5A623',
+        },
         status: {
           active:   '#F5A623',
           idle:     '#A09D99',


### PR DESCRIPTION
Replaces PR #20. Rebased onto main — no Layout Shell regression.

Closes #6

## Changes
- `src/pages/AgentsPage.tsx`: populated stub
- `src/components/agents/`: AgentCard (pulse), AgentGrid, AgentDetail (5-tab), MailboxViewer
- `server/api/agents.js`: wraps heartbeats/mailboxes/sessions-send.js CLI
- `src/lib/api.ts`: agent types + fetch functions appended
- `tailwind.config.js`: accent.{purple, purple-dim, purple-subtle} tokens added
- `server/index.js`: /api/agents router registered
- react-markdown added for INBOX.md tab

## Review (Архимед)
- ✅ App.tsx / main.tsx untouched (no regression)
- ✅ Design tokens used correctly
- ✅ CLI wrapping pattern followed