### PR TITLE
feat(#8): Logs page — LogViewer virtual-scroll + DecisionTrail + EventStream [rebased]

### DIFF
--- a/server/api/logs.js
+++ b/server/api/logs.js
@@ -1,0 +1,227 @@
+import { Router } from 'express'
+import { readFile, readdir, stat } from 'fs/promises'
+import { join, basename } from 'path'
+import { homedir } from 'os'
+
+const router = Router()
+
+const OPENCLAW_DIR = '/tmp/openclaw'
+const TASKS_DIR = join(homedir(), 'clawd/tasks/active')
+
+/**
+ * Compute today's date string in Lisbon timezone (YYYY-MM-DD).
+ */
+function todayLisbon() {
+  return new Date().toLocaleDateString('en-CA', { timeZone: 'Europe/Lisbon' })
+}
+
+/**
+ * Read the last N lines from a file.
+ */
+async function tailFile(filePath, lines = 200) {
+  try {
+    const content = await readFile(filePath, 'utf-8')
+    const allLines = content.split('\n').filter((l) => l.length > 0)
+    return allLines.slice(-lines)
+  } catch (err) {
+    if (err.code === 'ENOENT') return null
+    throw err
+  }
+}
+
+/**
+ * Parse NDJSON file into array of objects.
+ */
+async function parseNdjson(filePath) {
+  try {
+    const content = await readFile(filePath, 'utf-8')
+    return content
+      .split('\n')
+      .filter((l) => l.trim().length > 0)
+      .map((line) => {
+        try {
+          return JSON.parse(line)
+        } catch {
+          return null
+        }
+      })
+      .filter(Boolean)
+  } catch (err) {
+    if (err.code === 'ENOENT') return []
+    throw err
+  }
+}
+
+/**
+ * List subdirectories in a directory.
+ */
+async function listDirs(dirPath) {
+  try {
+    const entries = await readdir(dirPath, { withFileTypes: true })
+    return entries.filter((e) => e.isDirectory()).map((e) => e.name)
+  } catch {
+    return []
+  }
+}
+
+// GET /api/logs/gateway?lines=200
+router.get('/gateway', async (req, res) => {
+  try {
+    const lines = Math.min(Math.max(parseInt(req.query.lines) || 200, 1), 10000)
+    const dateStr = todayLisbon()
+    const logFile = join(OPENCLAW_DIR, `openclaw-${dateStr}.log`)
+
+    const result = await tailFile(logFile, lines)
+    if (result === null) {
+      return res.json({ lines: [], file_size_bytes: 0, file_date: dateStr, error: 'Log file not found' })
+    }
+
+    let fileSize = 0
+    try {
+      const s = await stat(logFile)
+      fileSize = s.size
+    } catch {
+      // ignore
+    }
+
+    res.json({ lines: result, file_size_bytes: fileSize, file_date: dateStr })
+  } catch (err) {
+    res.status(500).json({ error: err.message })
+  }
+})
+
+// GET /api/logs/worker — list all .log files in /tmp/openclaw/
+router.get('/worker', async (_req, res) => {
+  try {
+    let entries
+    try {
+      entries = await readdir(OPENCLAW_DIR)
+    } catch (err) {
+      if (err.code === 'ENOENT') return res.json({ files: [] })
+      throw err
+    }
+
+    const logFiles = entries.filter((f) => f.endsWith('.log'))
+    const files = await Promise.all(
+      logFiles.map(async (name) => {
+        try {
+          const s = await stat(join(OPENCLAW_DIR, name))
+          return { name, size_bytes: s.size }
+        } catch {
+          return { name, size_bytes: 0 }
+        }
+      })
+    )
+
+    res.json({ files })
+  } catch (err) {
+    res.status(500).json({ error: err.message })
+  }
+})
+
+// GET /api/logs/worker/:name?lines=100
+router.get('/worker/:name', async (req, res) => {
+  try {
+    const name = basename(req.params.name) // sanitize path traversal
+    if (!name.endsWith('.log')) {
+      return res.status(400).json({ error: 'Invalid log file name' })
+    }
+
+    const lines = Math.min(Math.max(parseInt(req.query.lines) || 100, 1), 10000)
+    const logFile = join(OPENCLAW_DIR, name)
+
+    const result = await tailFile(logFile, lines)
+    if (result === null) {
+      return res.status(404).json({ error: 'Log file not found' })
+    }
+
+    let fileSize = 0
+    try {
+      const s = await stat(logFile)
+      fileSize = s.size
+    } catch {
+      // ignore
+    }
+
+    res.json({ lines: result, file_size_bytes: fileSize, file_name: name })
+  } catch (err) {
+    res.status(500).json({ error: err.message })
+  }
+})
+
+// GET /api/decisions — aggregate decision-log.jsonl across all task dirs
+router.get('/decisions', async (req, res) => {
+  try {
+    const taskDirs = await listDirs(TASKS_DIR)
+    const allDecisions = []
+
+    for (const dir of taskDirs) {
+      const filePath = join(TASKS_DIR, dir, 'decision-log.jsonl')
+      const entries = await parseNdjson(filePath)
+      for (const entry of entries) {
+        allDecisions.push({ ...entry, _task_dir: dir })
+      }
+    }
+
+    // Filter by query params
+    let filtered = allDecisions
+    if (req.query.agent) {
+      filtered = filtered.filter((d) => d.agent === req.query.agent)
+    }
+    if (req.query.task_id) {
+      filtered = filtered.filter((d) => d.task_id === req.query.task_id)
+    }
+
+    // Sort by timestamp descending
+    filtered.sort((a, b) => {
+      const ta = a.timestamp || a.ts || ''
+      const tb = b.timestamp || b.ts || ''
+      return tb.localeCompare(ta)
+    })
+
+    res.json(filtered)
+  } catch (err) {
+    res.status(500).json({ error: err.message })
+  }
+})
+
+// GET /api/events — aggregate events.ndjson across all task dirs
+router.get('/events', async (req, res) => {
+  try {
+    const taskDirs = await listDirs(TASKS_DIR)
+    const allEvents = []
+
+    for (const dir of taskDirs) {
+      const filePath = join(TASKS_DIR, dir, 'events.ndjson')
+      const entries = await parseNdjson(filePath)
+      for (const entry of entries) {
+        allEvents.push({ ...entry, _task_dir: dir })
+      }
+    }
+
+    // Filter by query params
+    let filtered = allEvents
+    if (req.query.agent) {
+      filtered = filtered.filter((e) => e.agent === req.query.agent || e.actor === req.query.agent)
+    }
+    if (req.query.task_id) {
+      filtered = filtered.filter((e) => e.task_id === req.query.task_id)
+    }
+    if (req.query.type) {
+      filtered = filtered.filter((e) => e.type === req.query.type)
+    }
+
+    // Sort by timestamp descending
+    filtered.sort((a, b) => {
+      const ta = a.timestamp || a.ts || ''
+      const tb = b.timestamp || b.ts || ''
+      return tb.localeCompare(ta)
+    })
+
+    res.json(filtered)
+  } catch (err) {
+    res.status(500).json({ error: err.message })
+  }
+})
+
+export default router

--- a/server/index.js
+++ b/server/index.js
@@ -7,6 +7,7 @@ import tasksRouter from './api/tasks.js'
 import statusRouter from './api/status.js'
 import rateLimitsRouter from './api/rate-limits.js'
 import agentsRouter from './api/agents.js'
+import logsRouter from './api/logs.js'
 import { getGlobalStatus } from './lib/status.js'
 import { startVitalsWorker } from './lib/vitals.js'
 
@@ -34,6 +35,9 @@ app.use('/api/status', statusRouter)
 
 app.use('/api/rate-limits', rateLimitsRouter)
 app.use('/api/agents', agentsRouter)
+app.use('/api/logs', logsRouter)
+
+
 
 // ── Global status aggregator (TTL-cached, <200ms target) ─────────────────
 
@@ -59,4 +63,14 @@ startVitalsWorker(10_000)
 
 app.listen(PORT, () => {
   console.log(`[ao-dashboard] server listening on :${PORT}`)
+})
+
+// ── Decisions + Events (delegated to logs router) ─────────────────────────────
+app.get('/api/decisions', async (req, res) => {
+  req.url = '/decisions' + (req.url.includes('?') ? req.url.slice(req.url.indexOf('?')) : '')
+  logsRouter.handle(req, res, () => res.status(404).json({ error: 'not found' }))
+})
+app.get('/api/events', async (req, res) => {
+  req.url = '/events' + (req.url.includes('?') ? req.url.slice(req.url.indexOf('?')) : '')
+  logsRouter.handle(req, res, () => res.status(404).json({ error: 'not found' }))
 })

--- a/src/components/logs/DecisionTrail.tsx
+++ b/src/components/logs/DecisionTrail.tsx
@@ -1,0 +1,172 @@
+import { useState, useEffect, useMemo } from 'react'
+import { getDecisions, type Decision } from '../../lib/api'
+
+type SortField = 'agent' | 'task_id' | 'gate_type' | 'result' | 'timestamp'
+type SortDir = 'asc' | 'desc'
+
+const resultBadge: Record<string, string> = {
+  PASS: 'bg-accent-emerald-subtle text-accent-emerald',
+  FAIL: 'bg-accent-red-subtle text-accent-red',
+  DELEGATED: 'bg-accent-amber-subtle text-accent-amber',
+}
+
+export default function DecisionTrail() {
+  const [decisions, setDecisions] = useState<Decision[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [sortField, setSortField] = useState<SortField>('timestamp')
+  const [sortDir, setSortDir] = useState<SortDir>('desc')
+  const [filterAgent, setFilterAgent] = useState('')
+  const [filterTaskId, setFilterTaskId] = useState('')
+  const [filterDateFrom, setFilterDateFrom] = useState('')
+  const [filterDateTo, setFilterDateTo] = useState('')
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    getDecisions()
+      .then((data) => {
+        if (!cancelled) {
+          setDecisions(data)
+          setError(null)
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err.message)
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => { cancelled = true }
+  }, [])
+
+  const agents = useMemo(() => {
+    const set = new Set(decisions.map((d) => d.agent).filter(Boolean))
+    return Array.from(set).sort()
+  }, [decisions])
+
+  const filtered = useMemo(() => {
+    let result = decisions
+    if (filterAgent) result = result.filter((d) => d.agent === filterAgent)
+    if (filterTaskId) result = result.filter((d) => d.task_id?.includes(filterTaskId))
+    if (filterDateFrom) {
+      result = result.filter((d) => (d.timestamp || d.ts || '') >= filterDateFrom)
+    }
+    if (filterDateTo) {
+      result = result.filter((d) => (d.timestamp || d.ts || '') <= filterDateTo + 'T23:59:59')
+    }
+
+    result = [...result].sort((a, b) => {
+      const av = String((a as Record<string, unknown>)[sortField] ?? '')
+      const bv = String((b as Record<string, unknown>)[sortField] ?? '')
+      const cmp = av.localeCompare(bv)
+      return sortDir === 'asc' ? cmp : -cmp
+    })
+
+    return result
+  }, [decisions, filterAgent, filterTaskId, filterDateFrom, filterDateTo, sortField, sortDir])
+
+  function toggleSort(field: SortField) {
+    if (sortField === field) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'))
+    } else {
+      setSortField(field)
+      setSortDir('desc')
+    }
+  }
+
+  function sortIndicator(field: SortField) {
+    if (sortField !== field) return ''
+    return sortDir === 'asc' ? ' ↑' : ' ↓'
+  }
+
+  if (loading) {
+    return <div className="flex items-center justify-center h-full text-text-tertiary text-sm">Loading decisions…</div>
+  }
+  if (error) {
+    return <div className="flex items-center justify-center h-full text-accent-red text-sm">{error}</div>
+  }
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Filters */}
+      <div className="flex items-center gap-2 px-3 py-2 border-b border-border-subtle bg-bg-surface flex-wrap">
+        <select
+          value={filterAgent}
+          onChange={(e) => setFilterAgent(e.target.value)}
+          className="bg-bg-void border border-border text-text-primary text-xs font-mono px-2 py-1 rounded-sm"
+        >
+          <option value="">All Agents</option>
+          {agents.map((a) => (
+            <option key={a} value={a}>{a}</option>
+          ))}
+        </select>
+        <input
+          type="text"
+          placeholder="Task ID…"
+          value={filterTaskId}
+          onChange={(e) => setFilterTaskId(e.target.value)}
+          className="bg-bg-void border border-border text-text-primary text-xs font-mono px-2 py-1 rounded-sm w-32"
+        />
+        <input
+          type="date"
+          value={filterDateFrom}
+          onChange={(e) => setFilterDateFrom(e.target.value)}
+          className="bg-bg-void border border-border text-text-primary text-xs font-mono px-2 py-1 rounded-sm"
+        />
+        <span className="text-text-tertiary text-xs">to</span>
+        <input
+          type="date"
+          value={filterDateTo}
+          onChange={(e) => setFilterDateTo(e.target.value)}
+          className="bg-bg-void border border-border text-text-primary text-xs font-mono px-2 py-1 rounded-sm"
+        />
+        <span className="text-xs text-text-tertiary font-mono ml-auto">{filtered.length} rows</span>
+      </div>
+
+      {/* Table */}
+      <div className="flex-1 overflow-auto">
+        <table className="w-full text-xs font-mono">
+          <thead className="bg-bg-surface sticky top-0">
+            <tr className="text-text-tertiary text-left">
+              {(['agent', 'task_id', 'gate_type', 'result', 'timestamp'] as SortField[]).map((field) => (
+                <th
+                  key={field}
+                  onClick={() => toggleSort(field)}
+                  className="px-3 py-2 cursor-pointer hover:text-text-primary whitespace-nowrap"
+                >
+                  {field.replace('_', ' ').toUpperCase()}{sortIndicator(field)}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {filtered.length === 0 ? (
+              <tr>
+                <td colSpan={5} className="px-3 py-8 text-center text-text-tertiary">
+                  No decisions found
+                </td>
+              </tr>
+            ) : (
+              filtered.map((d, i) => (
+                <tr key={i} className="border-b border-border-subtle hover:bg-bg-hover">
+                  <td className="px-3 py-1.5">{d.agent || '—'}</td>
+                  <td className="px-3 py-1.5 text-accent-blue">{d.task_id || '—'}</td>
+                  <td className="px-3 py-1.5">{d.gate_type || '—'}</td>
+                  <td className="px-3 py-1.5">
+                    {d.result ? (
+                      <span className={`px-1.5 py-0.5 rounded-sm ${resultBadge[d.result] || 'bg-bg-elevated text-text-secondary'}`}>
+                        {d.result}
+                      </span>
+                    ) : '—'}
+                  </td>
+                  <td className="px-3 py-1.5 text-text-tertiary">{d.timestamp || d.ts || '—'}</td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/src/components/logs/EventStream.tsx
+++ b/src/components/logs/EventStream.tsx
@@ -1,0 +1,166 @@
+import { useState, useEffect, useMemo } from 'react'
+import { getEvents, type Event } from '../../lib/api'
+
+const eventIcons: Record<string, string> = {
+  state_transition: '⟳',
+  assignment: '→',
+  escalation: '⚠',
+  delegation: '↗',
+  completion: '✓',
+  failure: '✗',
+  start: '▶',
+  pause: '⏸',
+  resume: '▶',
+  created: '+',
+}
+
+function getEventIcon(type?: string): string {
+  if (!type) return '•'
+  return eventIcons[type] || '•'
+}
+
+export default function EventStream() {
+  const [events, setEvents] = useState<Event[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [filterTaskId, setFilterTaskId] = useState('')
+  const [filterAgent, setFilterAgent] = useState('')
+  const [filterType, setFilterType] = useState('')
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    getEvents()
+      .then((data) => {
+        if (!cancelled) {
+          setEvents(data)
+          setError(null)
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err.message)
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => { cancelled = true }
+  }, [])
+
+  const agents = useMemo(() => {
+    const set = new Set(events.map((e) => e.actor || e.agent).filter(Boolean))
+    return Array.from(set).sort() as string[]
+  }, [events])
+
+  const eventTypes = useMemo(() => {
+    const set = new Set(events.map((e) => e.type).filter(Boolean))
+    return Array.from(set).sort() as string[]
+  }, [events])
+
+  const filtered = useMemo(() => {
+    let result = events
+    if (filterTaskId) result = result.filter((e) => e.task_id?.includes(filterTaskId))
+    if (filterAgent) result = result.filter((e) => (e.actor || e.agent) === filterAgent)
+    if (filterType) result = result.filter((e) => e.type === filterType)
+    return result
+  }, [events, filterTaskId, filterAgent, filterType])
+
+  if (loading) {
+    return <div className="flex items-center justify-center h-full text-text-tertiary text-sm">Loading events…</div>
+  }
+  if (error) {
+    return <div className="flex items-center justify-center h-full text-accent-red text-sm">{error}</div>
+  }
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Filters */}
+      <div className="flex items-center gap-2 px-3 py-2 border-b border-border-subtle bg-bg-surface flex-wrap">
+        <input
+          type="text"
+          placeholder="Task ID…"
+          value={filterTaskId}
+          onChange={(e) => setFilterTaskId(e.target.value)}
+          className="bg-bg-void border border-border text-text-primary text-xs font-mono px-2 py-1 rounded-sm w-32"
+        />
+        <select
+          value={filterAgent}
+          onChange={(e) => setFilterAgent(e.target.value)}
+          className="bg-bg-void border border-border text-text-primary text-xs font-mono px-2 py-1 rounded-sm"
+        >
+          <option value="">All Actors</option>
+          {agents.map((a) => (
+            <option key={a} value={a}>{a}</option>
+          ))}
+        </select>
+        <select
+          value={filterType}
+          onChange={(e) => setFilterType(e.target.value)}
+          className="bg-bg-void border border-border text-text-primary text-xs font-mono px-2 py-1 rounded-sm"
+        >
+          <option value="">All Types</option>
+          {eventTypes.map((t) => (
+            <option key={t} value={t}>{t}</option>
+          ))}
+        </select>
+        <span className="text-xs text-text-tertiary font-mono ml-auto">{filtered.length} events</span>
+      </div>
+
+      {/* Event feed */}
+      <div className="flex-1 overflow-auto">
+        {filtered.length === 0 ? (
+          <div className="flex items-center justify-center h-full text-text-tertiary text-sm">
+            No events found
+          </div>
+        ) : (
+          <div className="divide-y divide-border-subtle">
+            {filtered.map((evt, i) => {
+              const actor = evt.actor || evt.agent
+              const ts = evt.timestamp || evt.ts
+              const dataSummary = evt.data
+                ? Object.entries(evt.data)
+                    .map(([k, v]) => `${k}: ${typeof v === 'object' ? JSON.stringify(v) : String(v)}`)
+                    .join(', ')
+                : null
+
+              return (
+                <div key={i} className="flex items-start gap-3 px-3 py-2 hover:bg-bg-hover">
+                  {/* Icon */}
+                  <span className="text-md mt-0.5 w-5 text-center shrink-0 text-text-tertiary">
+                    {getEventIcon(evt.type)}
+                  </span>
+
+                  {/* Content */}
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      {evt.type && (
+                        <span className="text-xs font-mono text-text-primary">{evt.type}</span>
+                      )}
+                      {actor && (
+                        <span className="px-1.5 py-0.5 rounded-sm text-xs font-mono bg-accent-blue-subtle text-accent-blue">
+                          {actor}
+                        </span>
+                      )}
+                      {evt.task_id && (
+                        <span className="px-1.5 py-0.5 rounded-sm text-xs font-mono bg-bg-elevated text-text-secondary">
+                          {evt.task_id}
+                        </span>
+                      )}
+                      {ts && (
+                        <span className="text-xs font-mono text-text-tertiary ml-auto shrink-0">
+                          {ts}
+                        </span>
+                      )}
+                    </div>
+                    {dataSummary && (
+                      <p className="text-xs text-text-tertiary mt-0.5 truncate">{dataSummary}</p>
+                    )}
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/logs/LogViewer.tsx
+++ b/src/components/logs/LogViewer.tsx
@@ -1,0 +1,192 @@
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react'
+import { useVirtualizer } from '@tanstack/react-virtual'
+
+interface LogViewerProps {
+  lines: string[]
+  loading?: boolean
+  error?: string
+  paused?: boolean
+}
+
+type LogLevel = 'ERROR' | 'WARN' | 'INFO' | 'DEBUG'
+const ALL_LEVELS: LogLevel[] = ['ERROR', 'WARN', 'INFO', 'DEBUG']
+
+function detectLevel(line: string): LogLevel {
+  if (/\bERROR\b/.test(line)) return 'ERROR'
+  if (/\bWARN(?:ING)?\b/.test(line)) return 'WARN'
+  if (/\bDEBUG\b/.test(line)) return 'DEBUG'
+  return 'INFO'
+}
+
+const levelStyles: Record<LogLevel, string> = {
+  ERROR: 'text-accent-red bg-accent-red-subtle',
+  WARN: 'text-accent-amber',
+  INFO: 'text-text-secondary',
+  DEBUG: 'text-text-tertiary',
+}
+
+export default function LogViewer({ lines, loading, error, paused }: LogViewerProps) {
+  const [selectedLevels, setSelectedLevels] = useState<Set<LogLevel>>(new Set(ALL_LEVELS))
+  const [keyword, setKeyword] = useState('')
+  const [expandedLine, setExpandedLine] = useState<number | null>(null)
+  const parentRef = useRef<HTMLDivElement>(null)
+  const shouldAutoScroll = useRef(true)
+
+  const filteredLines = useMemo(() => {
+    return lines
+      .map((line, i) => ({ line, index: i, level: detectLevel(line) }))
+      .filter(({ level }) => selectedLevels.has(level))
+      .filter(({ line }) => !keyword || line.toLowerCase().includes(keyword.toLowerCase()))
+  }, [lines, selectedLevels, keyword])
+
+  const virtualizer = useVirtualizer({
+    count: filteredLines.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => 20,
+    overscan: 20,
+  })
+
+  // Auto-scroll to bottom when not paused
+  useEffect(() => {
+    if (!paused && shouldAutoScroll.current && parentRef.current) {
+      virtualizer.scrollToIndex(filteredLines.length - 1, { align: 'end' })
+    }
+  }, [filteredLines.length, paused, virtualizer])
+
+  // Track if user has scrolled away from bottom
+  const handleScroll = useCallback(() => {
+    if (!parentRef.current || paused) return
+    const { scrollTop, scrollHeight, clientHeight } = parentRef.current
+    shouldAutoScroll.current = scrollHeight - scrollTop - clientHeight < 50
+  }, [paused])
+
+  // When paused, lock scroll position
+  useEffect(() => {
+    if (paused) {
+      shouldAutoScroll.current = false
+    } else {
+      shouldAutoScroll.current = true
+    }
+  }, [paused])
+
+  function toggleLevel(level: LogLevel) {
+    setSelectedLevels((prev) => {
+      const next = new Set(prev)
+      if (next.has(level)) {
+        next.delete(level)
+      } else {
+        next.add(level)
+      }
+      return next
+    })
+  }
+
+  function tryParseJson(line: string): string | null {
+    // Try to extract JSON from the log line
+    const jsonMatch = line.match(/\{[\s\S]*\}/)
+    if (jsonMatch) {
+      try {
+        return JSON.stringify(JSON.parse(jsonMatch[0]), null, 2)
+      } catch {
+        return null
+      }
+    }
+    return null
+  }
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Filter bar */}
+      <div className="flex items-center gap-2 px-3 py-2 border-b border-border-subtle bg-bg-surface">
+        {ALL_LEVELS.map((level) => (
+          <button
+            key={level}
+            onClick={() => toggleLevel(level)}
+            className={`px-2 py-0.5 rounded-sm text-xs font-mono transition-colors ${
+              selectedLevels.has(level)
+                ? level === 'ERROR'
+                  ? 'bg-accent-red-subtle text-accent-red'
+                  : level === 'WARN'
+                    ? 'bg-accent-amber-subtle text-accent-amber'
+                    : level === 'INFO'
+                      ? 'bg-bg-elevated text-text-secondary'
+                      : 'bg-bg-elevated text-text-tertiary'
+                : 'bg-bg-void text-text-disabled'
+            }`}
+          >
+            {level}
+          </button>
+        ))}
+        <input
+          type="text"
+          placeholder="Filter by keyword…"
+          value={keyword}
+          onChange={(e) => setKeyword(e.target.value)}
+          className="ml-2 flex-1 bg-bg-void border border-border text-text-primary text-xs font-mono px-2 py-1 rounded-sm focus:border-accent-amber focus:outline-none"
+        />
+        <span className="text-xs text-text-tertiary font-mono">
+          {filteredLines.length}/{lines.length}
+        </span>
+      </div>
+
+      {/* Log content */}
+      {error ? (
+        <div className="flex-1 flex items-center justify-center text-text-tertiary text-sm">
+          {error}
+        </div>
+      ) : loading && lines.length === 0 ? (
+        <div className="flex-1 flex items-center justify-center text-text-tertiary text-sm">
+          Loading logs…
+        </div>
+      ) : (
+        <div
+          ref={parentRef}
+          onScroll={handleScroll}
+          className="flex-1 overflow-auto font-mono text-xs"
+        >
+          <div
+            style={{
+              height: `${virtualizer.getTotalSize()}px`,
+              width: '100%',
+              position: 'relative',
+            }}
+          >
+            {virtualizer.getVirtualItems().map((virtualRow) => {
+              const item = filteredLines[virtualRow.index]
+              if (!item) return null
+              const isExpanded = expandedLine === item.index
+              const jsonDetail = isExpanded ? tryParseJson(item.line) : null
+
+              return (
+                <div
+                  key={virtualRow.key}
+                  data-index={virtualRow.index}
+                  ref={virtualizer.measureElement}
+                  style={{
+                    position: 'absolute',
+                    top: 0,
+                    left: 0,
+                    width: '100%',
+                    transform: `translateY(${virtualRow.start}px)`,
+                  }}
+                >
+                  <div
+                    onClick={() => setExpandedLine(isExpanded ? null : item.index)}
+                    className={`px-3 py-0.5 cursor-pointer hover:bg-bg-hover leading-relaxed break-all ${levelStyles[item.level]}`}
+                  >
+                    {item.line}
+                  </div>
+                  {isExpanded && jsonDetail && (
+                    <pre className="px-6 py-2 bg-bg-elevated text-text-secondary text-xs border-l-2 border-accent-amber whitespace-pre-wrap">
+                      {jsonDetail}
+                    </pre>
+                  )}
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -231,3 +231,50 @@ export async function moveEnvelope(agentId: string, fromFolder: string, toFolder
   });
   return res.json();
 }
+
+// ─── Logs ────────────────────────────────────────────────────────────────────
+
+export interface GatewayLogResponse {
+  lines: string[]; file_size_bytes: number; file_date: string; error?: string;
+}
+export interface WorkerFile { name: string; size_bytes: number }
+export interface WorkerListResponse { files: WorkerFile[] }
+export interface WorkerLogResponse { lines: string[]; file_size_bytes: number; file_name: string }
+export interface Decision {
+  agent?: string; task_id?: string; gate_type?: string; result?: string;
+  timestamp?: string; ts?: string; _task_dir?: string; [key: string]: unknown;
+}
+export interface LogEvent {
+  type?: string; actor?: string; agent?: string; task_id?: string;
+  timestamp?: string; ts?: string; data?: Record<string, unknown>;
+  _task_dir?: string; [key: string]: unknown;
+}
+
+export function getGatewayLog(lines = 200): Promise<GatewayLogResponse> {
+  return fetchJson<GatewayLogResponse>(`/api/logs/gateway?lines=${lines}`)
+}
+export function getWorkerList(): Promise<WorkerListResponse> {
+  return fetchJson<WorkerListResponse>('/api/logs/worker')
+}
+export function getWorkerLog(name: string, lines = 100): Promise<WorkerLogResponse> {
+  return fetchJson<WorkerLogResponse>(`/api/logs/worker/${encodeURIComponent(name)}?lines=${lines}`)
+}
+export function getDecisions(params?: { agent?: string; task_id?: string }): Promise<Decision[]> {
+  const sp = new URLSearchParams()
+  if (params?.agent) sp.set('agent', params.agent)
+  if (params?.task_id) sp.set('task_id', params.task_id)
+  const qs = sp.toString()
+  return fetchJson<Decision[]>(`/api/decisions${qs ? `?${qs}` : ''}`)
+}
+export function getLogEvents(params?: { agent?: string; task_id?: string; type?: string }): Promise<LogEvent[]> {
+  const sp = new URLSearchParams()
+  if (params?.agent) sp.set('agent', params.agent)
+  if (params?.task_id) sp.set('task_id', params.task_id)
+  if (params?.type) sp.set('type', params.type)
+  const qs = sp.toString()
+  return fetchJson<LogEvent[]>(`/api/events${qs ? `?${qs}` : ''}`)
+}
+
+// Aliases for backwards-compat with Logs components
+export { getLogEvents as getEvents }
+export type { LogEvent as Event }

--- a/src/pages/LogsPage.tsx
+++ b/src/pages/LogsPage.tsx
@@ -1,8 +1,184 @@
+import { useState, useEffect, useCallback } from 'react'
+import LogViewer from '../components/logs/LogViewer'
+import DecisionTrail from '../components/logs/DecisionTrail'
+import EventStream from '../components/logs/EventStream'
+import { getGatewayLog, getWorkerList, getWorkerLog, type WorkerFile } from '../lib/api'
+
+type Tab = 'gateway' | 'workers' | 'decisions' | 'events'
+
+const POLL_INTERVAL = 5000
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
 export default function LogsPage() {
+  const [activeTab, setActiveTab] = useState<Tab>('gateway')
+
+  // Gateway state
+  const [gatewayLines, setGatewayLines] = useState<string[]>([])
+  const [gatewayError, setGatewayError] = useState<string | null>(null)
+  const [gatewayLoading, setGatewayLoading] = useState(true)
+  const [paused, setPaused] = useState(false)
+
+  // Worker state
+  const [workerFiles, setWorkerFiles] = useState<WorkerFile[]>([])
+  const [selectedWorker, setSelectedWorker] = useState<string>('')
+  const [workerLines, setWorkerLines] = useState<string[]>([])
+  const [workerLoading, setWorkerLoading] = useState(false)
+  const [workerError, setWorkerError] = useState<string | null>(null)
+
+  // Gateway polling
+  const fetchGateway = useCallback(async () => {
+    try {
+      const data = await getGatewayLog(200)
+      if (data.error) {
+        setGatewayError(data.error)
+        setGatewayLines([])
+      } else {
+        setGatewayLines(data.lines)
+        setGatewayError(null)
+      }
+    } catch (err) {
+      setGatewayError(err instanceof Error ? err.message : 'Failed to load logs')
+    } finally {
+      setGatewayLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (activeTab !== 'gateway') return
+    fetchGateway()
+    if (paused) return
+
+    const id = setInterval(fetchGateway, POLL_INTERVAL)
+    return () => clearInterval(id)
+  }, [activeTab, paused, fetchGateway])
+
+  // Worker file list
+  useEffect(() => {
+    if (activeTab !== 'workers') return
+    getWorkerList()
+      .then((data) => setWorkerFiles(data.files))
+      .catch(() => setWorkerFiles([]))
+  }, [activeTab])
+
+  // Worker log fetch
+  useEffect(() => {
+    if (!selectedWorker) {
+      setWorkerLines([])
+      return
+    }
+    setWorkerLoading(true)
+    setWorkerError(null)
+    getWorkerLog(selectedWorker, 100)
+      .then((data) => {
+        setWorkerLines(data.lines)
+        setWorkerError(null)
+      })
+      .catch((err) => {
+        setWorkerError(err instanceof Error ? err.message : 'Failed to load log')
+        setWorkerLines([])
+      })
+      .finally(() => setWorkerLoading(false))
+  }, [selectedWorker])
+
+  const tabs: { key: Tab; label: string }[] = [
+    { key: 'gateway', label: 'Gateway' },
+    { key: 'workers', label: 'Workers' },
+    { key: 'decisions', label: 'Decisions' },
+    { key: 'events', label: 'Events' },
+  ]
+
   return (
-    <div>
-      <h1 className="text-xl font-bold mb-4">Logs & Observability</h1>
-      <p className="text-text-secondary">Logs view — awaiting implementation.</p>
+    <div className="flex flex-col h-screen bg-bg-base">
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-border-subtle">
+        <h1 className="text-lg font-semibold text-text-primary">Logs</h1>
+        {activeTab === 'gateway' && (
+          <button
+            onClick={() => setPaused((p) => !p)}
+            className={`px-3 py-1 rounded-sm text-xs font-mono font-semibold transition-colors ${
+              paused
+                ? 'bg-accent-emerald-subtle text-accent-emerald'
+                : 'bg-accent-amber-subtle text-accent-amber'
+            }`}
+          >
+            {paused ? '▶ Resume' : '⏸ Pause'}
+          </button>
+        )}
+      </div>
+
+      {/* Tabs */}
+      <div className="flex border-b border-border-subtle bg-bg-surface">
+        {tabs.map(({ key, label }) => (
+          <button
+            key={key}
+            onClick={() => setActiveTab(key)}
+            className={`px-4 py-2 text-sm font-medium transition-colors border-b-2 ${
+              activeTab === key
+                ? 'border-accent-amber text-text-primary'
+                : 'border-transparent text-text-tertiary hover:text-text-secondary'
+            }`}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {/* Tab content */}
+      <div className="flex-1 min-h-0">
+        {activeTab === 'gateway' && (
+          <LogViewer
+            lines={gatewayLines}
+            loading={gatewayLoading}
+            error={gatewayError ?? undefined}
+            paused={paused}
+          />
+        )}
+
+        {activeTab === 'workers' && (
+          <div className="flex flex-col h-full">
+            {/* Worker file selector */}
+            <div className="flex items-center gap-2 px-3 py-2 border-b border-border-subtle bg-bg-surface">
+              <select
+                value={selectedWorker}
+                onChange={(e) => setSelectedWorker(e.target.value)}
+                className="bg-bg-void border border-border text-text-primary text-xs font-mono px-2 py-1 rounded-sm flex-1 max-w-xs"
+              >
+                <option value="">Select a worker log…</option>
+                {workerFiles.map((f) => (
+                  <option key={f.name} value={f.name}>
+                    {f.name} ({formatBytes(f.size_bytes)})
+                  </option>
+                ))}
+              </select>
+              {workerFiles.length === 0 && (
+                <span className="text-xs text-text-tertiary">No worker log files found</span>
+              )}
+            </div>
+            <div className="flex-1 min-h-0">
+              {selectedWorker ? (
+                <LogViewer
+                  lines={workerLines}
+                  loading={workerLoading}
+                  error={workerError ?? undefined}
+                />
+              ) : (
+                <div className="flex items-center justify-center h-full text-text-tertiary text-sm">
+                  Select a worker log file to view
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+
+        {activeTab === 'decisions' && <DecisionTrail />}
+
+        {activeTab === 'events' && <EventStream />}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
Replaces PR #21. Rebased onto main — no Layout Shell regression, non-Leo colors removed.

Closes #8

## Changes
- `src/pages/LogsPage.tsx`: populated stub
- `src/components/logs/`: LogViewer (virtual scroll via @tanstack/react-virtual), DecisionTrail, EventStream
- `server/api/logs.js`: reads gateway logs, worker logs, decisions (decision-log.jsonl), events (events.ndjson)
- `src/lib/api.ts`: log types + fetch functions appended
- `server/index.js`: /api/logs, /api/decisions, /api/events registered

## Review
- ✅ App.tsx / main.tsx untouched
- ✅ Non-Leo tailwind colors removed
- ✅ CLI pattern: filesystem reads from real paths