### PR TITLE
feat(#9): Config page — ConfigViewer + SkillsBrowser + MemoryBrowser read-only [rebased]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,11 +11,15 @@
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
+        "@tanstack/react-virtual": "^3.13.23",
+        "@types/react-syntax-highlighter": "^15.5.13",
         "express": "^4.18.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-markdown": "^10.1.0",
-        "react-router-dom": "^6.30.3"
+        "react-router-dom": "^6.30.3",
+        "react-syntax-highlighter": "^16.1.1",
+        "remark-gfm": "^4.0.1"
       },
       "devDependencies": {
         "@types/express": "^4.17.21",
@@ -307,7 +311,6 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1408,6 +1411,33 @@
         "win32"
       ]
     },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.13.23",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.23.tgz",
+      "integrity": "sha512-XnMRnHQ23piOVj2bzJqHrRrLg4r+F86fuBcwteKfbIjJrtGxb4z7tIvPVAe4B+4UVwo9G4Giuz5fmapcrnZ0OQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.13.23"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.13.23",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.23.tgz",
+      "integrity": "sha512-zSz2Z2HNyLjCplANTDyl3BcdQJc2k1+yyFoKhNRmCr7V7dY8o8q5m8uFTI1/Pg1kL+Hgrz6u3Xo6eFUB7l66cg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1572,6 +1602,12 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/prismjs": {
+      "version": "1.26.6",
+      "resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.6.tgz",
+      "integrity": "sha512-vqlvI7qlMvcCBbVe0AKAb4f97//Hy0EBTaiW8AalRnG/xAN5zOiWWyrNqNXeq8+KAuvRewjCVY1+IPxk4RdNYw==",
+      "license": "MIT"
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
@@ -1610,6 +1646,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@types/react-syntax-highlighter": {
+      "version": "15.5.13",
+      "resolved": "https://registry.npmjs.org/@types/react-syntax-highlighter/-/react-syntax-highlighter-15.5.13.tgz",
+      "integrity": "sha512-uLGJ87j6Sz8UaBAooU0T6lWJ0dBmjZgN1PZTrj05TNql2/XpC6+4HhMT5syIdFUUt+FASfCeLLv4kBygNU+8qA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/send": {
@@ -3162,6 +3207,19 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fault": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/fault/-/fault-1.0.4.tgz",
+      "integrity": "sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==",
+      "license": "MIT",
+      "dependencies": {
+        "format": "^0.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -3259,6 +3317,14 @@
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/format": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
+      "integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==",
+      "engines": {
+        "node": ">=0.4.x"
+      }
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
@@ -3529,6 +3595,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-parse-selector": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-jsx-runtime": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
@@ -3568,6 +3647,38 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/hastscript": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^4.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/highlightjs-vue": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/highlightjs-vue/-/highlightjs-vue-1.0.0.tgz",
+      "integrity": "sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA==",
+      "license": "CC0-1.0"
     },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
@@ -3998,6 +4109,20 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/lowlight": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.20.0.tgz",
+      "integrity": "sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==",
+      "license": "MIT",
+      "dependencies": {
+        "fault": "^1.0.0",
+        "highlight.js": "~10.7.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -4008,6 +4133,16 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -4015,6 +4150,34 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mdast-util-from-markdown": {
@@ -4035,6 +4198,107 @@
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0",
         "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -4274,6 +4538,127 @@
         "micromark-util-subtokenize": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/micromark-factory-destination": {
@@ -5199,6 +5584,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prismjs": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/property-information": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
@@ -5386,6 +5780,26 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/react-syntax-highlighter": {
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-16.1.1.tgz",
+      "integrity": "sha512-PjVawBGy80C6YbC5DDZJeUjBmC7skaoEUdvfFQediQHgCL7aKyVHe57SaJGfQsloGDac+gCpTfRdtxzWWKmCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.4",
+        "highlight.js": "^10.4.1",
+        "highlightjs-vue": "^1.0.0",
+        "lowlight": "^1.17.0",
+        "prismjs": "^1.30.0",
+        "refractor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 16.20.2"
+      },
+      "peerDependencies": {
+        "react": ">= 0.14.0"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -5407,6 +5821,40 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/refractor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/refractor/-/refractor-5.0.0.tgz",
+      "integrity": "sha512-QXOrHQF5jOpjjLfiNk5GFnWhRXvxjUVnlFxkeDmewR5sXkr3iM46Zo+CnRR8B+MDVqkULW4EcLVcRBNOPXHosw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/prismjs": "^1.0.0",
+        "hastscript": "^9.0.0",
+        "parse-entities": "^4.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/remark-parse": {
@@ -5436,6 +5884,21 @@
         "mdast-util-to-hast": "^13.0.0",
         "unified": "^11.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -17,11 +17,15 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@tanstack/react-virtual": "^3.13.23",
+    "@types/react-syntax-highlighter": "^15.5.13",
     "express": "^4.18.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-markdown": "^10.1.0",
-    "react-router-dom": "^6.30.3"
+    "react-router-dom": "^6.30.3",
+    "react-syntax-highlighter": "^16.1.1",
+    "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/server/api/config.js
+++ b/server/api/config.js
@@ -1,0 +1,59 @@
+import { Router } from 'express'
+import { readFile } from 'fs/promises'
+import { join } from 'path'
+import { homedir } from 'os'
+
+const router = Router()
+
+const SECRETS_RE = /token|key|secret|password|bearer|auth/i
+
+/** Recursively redact values whose key matches the secrets pattern */
+function redactSecrets(obj) {
+  if (obj === null || typeof obj !== 'object') return obj
+  if (Array.isArray(obj)) return obj.map(redactSecrets)
+
+  const out = {}
+  for (const [k, v] of Object.entries(obj)) {
+    if (SECRETS_RE.test(k) && typeof v === 'string') {
+      out[k] = '••••••••'
+    } else if (typeof v === 'object' && v !== null) {
+      out[k] = redactSecrets(v)
+    } else {
+      out[k] = v
+    }
+  }
+  return out
+}
+
+/** GET /api/config/gateway — structured openclaw.json with secrets redacted */
+router.get('/gateway', async (_req, res) => {
+  try {
+    const configPath = join(homedir(), '.openclaw', 'openclaw.json')
+    const raw = await readFile(configPath, 'utf-8')
+    const parsed = JSON.parse(raw)
+    res.json(redactSecrets(parsed))
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      return res.json({ content: null, error: 'not found' })
+    }
+    console.error('[config/gateway]', err)
+    res.status(500).json({ error: 'failed to read config' })
+  }
+})
+
+/** GET /api/config/team-manifest — raw markdown content */
+router.get('/team-manifest', async (_req, res) => {
+  try {
+    const manifestPath = join(homedir(), '.openclaw', 'shared-memory', 'team-manifest.md')
+    const content = await readFile(manifestPath, 'utf-8')
+    res.json({ content })
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      return res.json({ content: null, error: 'not found' })
+    }
+    console.error('[config/team-manifest]', err)
+    res.status(500).json({ error: 'failed to read team manifest' })
+  }
+})
+
+export default router

--- a/server/api/memory.js
+++ b/server/api/memory.js
@@ -1,0 +1,110 @@
+import { Router } from 'express'
+import { readFile, readdir } from 'fs/promises'
+import { join, extname } from 'path'
+import { homedir } from 'os'
+
+const router = Router()
+
+const KNOWN_FILES = ['MEMORY.md', 'AGENTS.md', 'SOUL.md', 'USER.md', 'TOOLS.md', 'HEARTBEAT.md', 'IDENTITY.md', 'BOOTSTRAP.md', 'SESSION-STATE.md', 'INBOX.md']
+const DATE_RE = /^\d{4}-\d{2}-\d{2}\.md$/
+
+function agentWorkspacePath(agent) {
+  const home = homedir()
+  if (agent === 'shared') {
+    return join(home, '.openclaw', 'shared-memory')
+  }
+  return join(home, '.openclaw', `workspace-${agent}`)
+}
+
+/** GET /api/memory/:agent/files — list available memory files and daily note dates */
+router.get('/:agent/files', async (req, res) => {
+  try {
+    const wsPath = agentWorkspacePath(req.params.agent)
+
+    // List top-level known files
+    const files = []
+    for (const f of KNOWN_FILES) {
+      try {
+        await readFile(join(wsPath, f), 'utf-8')
+        files.push(f)
+      } catch {
+        // file doesn't exist
+      }
+    }
+
+    // Check for json files in workspace
+    try {
+      const entries = await readdir(wsPath)
+      for (const e of entries) {
+        if (e.endsWith('.json')) {
+          files.push(e)
+        }
+      }
+    } catch {
+      // dir doesn't exist
+    }
+
+    // List daily notes from memory/ subdirectory
+    const dailyDates = []
+    try {
+      const memDir = join(wsPath, 'memory')
+      const memEntries = await readdir(memDir)
+      for (const e of memEntries) {
+        if (DATE_RE.test(e)) {
+          dailyDates.push(e.replace('.md', ''))
+        }
+      }
+    } catch {
+      // no memory dir
+    }
+
+    res.json({ files, dailyDates })
+  } catch (err) {
+    console.error('[memory/files]', err)
+    res.status(500).json({ error: 'failed to list files' })
+  }
+})
+
+/** GET /api/memory/:agent/daily/:date — read daily note */
+router.get('/:agent/daily/:date', async (req, res) => {
+  try {
+    const wsPath = agentWorkspacePath(req.params.agent)
+    const filePath = join(wsPath, 'memory', `${req.params.date}.md`)
+    const content = await readFile(filePath, 'utf-8')
+    res.json({ content, type: 'markdown' })
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      return res.json({ content: null, error: 'not found' })
+    }
+    console.error('[memory/daily]', err)
+    res.status(500).json({ error: 'failed to read daily note' })
+  }
+})
+
+/** GET /api/memory/:agent/:file — read a specific memory file */
+router.get('/:agent/:file', async (req, res) => {
+  try {
+    const wsPath = agentWorkspacePath(req.params.agent)
+    const fileName = req.params.file
+    const filePath = join(wsPath, fileName)
+
+    // Prevent path traversal
+    if (fileName.includes('..') || fileName.includes('/')) {
+      return res.status(400).json({ error: 'invalid file name' })
+    }
+
+    const content = await readFile(filePath, 'utf-8')
+    const ext = extname(fileName).toLowerCase()
+    const type = ext === '.json' ? 'json' : 'markdown'
+
+    res.json({ content, type })
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      return res.json({ content: null, error: 'not found' })
+    }
+    console.error('[memory/file]', err)
+    res.status(500).json({ error: 'failed to read file' })
+  }
+})
+
+export default router

--- a/server/api/skills.js
+++ b/server/api/skills.js
@@ -1,0 +1,78 @@
+import { Router } from 'express'
+import { readFile, readdir, stat } from 'fs/promises'
+import { join, basename, dirname } from 'path'
+import { homedir } from 'os'
+import { glob } from 'fs'
+import { promisify } from 'util'
+
+const router = Router()
+
+/** Recursively find SKILL.md files under a directory */
+async function findSkillFiles(dir) {
+  const results = []
+  try {
+    const entries = await readdir(dir, { withFileTypes: true })
+    for (const entry of entries) {
+      const fullPath = join(dir, entry.name)
+      if (entry.isDirectory()) {
+        // Check for SKILL.md directly in this skill folder
+        const skillMd = join(fullPath, 'SKILL.md')
+        try {
+          const st = await stat(skillMd)
+          const content = await readFile(skillMd, 'utf-8')
+          results.push({
+            name: entry.name,
+            path: skillMd,
+            size: st.size,
+            content,
+          })
+        } catch {
+          // No SKILL.md in this dir, recurse
+          const nested = await findSkillFiles(fullPath)
+          results.push(...nested)
+        }
+      }
+    }
+  } catch {
+    // Directory doesn't exist or not readable
+  }
+  return results
+}
+
+/** GET /api/skills — scan all workspace skill directories */
+router.get('/', async (_req, res) => {
+  try {
+    const home = homedir()
+    const openclawDir = join(home, '.openclaw')
+
+    // Find all workspace-* directories
+    const entries = await readdir(openclawDir, { withFileTypes: true })
+    const workspaces = entries
+      .filter(e => e.isDirectory() && e.name.startsWith('workspace-'))
+      .map(e => ({
+        agent: e.name.replace('workspace-', ''),
+        path: join(openclawDir, e.name, 'skills'),
+      }))
+
+    // Also include global skills
+    workspaces.push({
+      agent: 'global',
+      path: join(openclawDir, 'skills'),
+    })
+
+    const result = {}
+    for (const ws of workspaces) {
+      const skills = await findSkillFiles(ws.path)
+      if (skills.length > 0) {
+        result[ws.agent] = skills
+      }
+    }
+
+    res.json(result)
+  } catch (err) {
+    console.error('[skills]', err)
+    res.status(500).json({ error: 'failed to scan skills' })
+  }
+})
+
+export default router

--- a/server/index.js
+++ b/server/index.js
@@ -8,6 +8,9 @@ import statusRouter from './api/status.js'
 import rateLimitsRouter from './api/rate-limits.js'
 import agentsRouter from './api/agents.js'
 import logsRouter from './api/logs.js'
+import configRouter from './api/config.js'
+import memoryRouter from './api/memory.js'
+import skillsRouter from './api/skills.js'
 import { getGlobalStatus } from './lib/status.js'
 import { startVitalsWorker } from './lib/vitals.js'
 
@@ -36,6 +39,9 @@ app.use('/api/status', statusRouter)
 app.use('/api/rate-limits', rateLimitsRouter)
 app.use('/api/agents', agentsRouter)
 app.use('/api/logs', logsRouter)
+app.use('/api/config', configRouter)
+app.use('/api/memory', memoryRouter)
+app.use('/api/skills', skillsRouter)
 
 
 

--- a/src/components/config/ConfigViewer.tsx
+++ b/src/components/config/ConfigViewer.tsx
@@ -1,0 +1,152 @@
+import { useState, useEffect } from 'react'
+
+const SECTION_ORDER = ['agents', 'auth', 'memory', 'session', 'gateway', 'models', 'tools', 'hooks', 'channels', 'bindings', 'commands', 'skills', 'plugins', 'browser', 'meta', 'wizard']
+
+function isRedacted(value: unknown): boolean {
+  return value === '••••••••'
+}
+
+function ConfigValue({ label, value }: { label: string; value: unknown }) {
+  if (value === null || value === undefined) return null
+
+  if (isRedacted(value)) {
+    return (
+      <div className="flex items-center gap-2 py-1">
+        <span className="text-text-secondary text-sm min-w-[180px] font-mono">{label}</span>
+        <span className="text-text-tertiary text-sm font-mono flex items-center gap-1">
+          <svg className="w-3 h-3" viewBox="0 0 16 16" fill="currentColor">
+            <path d="M8 1a4 4 0 0 0-4 4v3H3a1 1 0 0 0-1 1v5a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1V9a1 1 0 0 0-1-1h-1V5a4 4 0 0 0-4-4zm2 7H6V5a2 2 0 1 1 4 0v3z"/>
+          </svg>
+          ••••••••
+        </span>
+      </div>
+    )
+  }
+
+  if (typeof value === 'object' && !Array.isArray(value)) {
+    return (
+      <ConfigSection label={label} data={value as Record<string, unknown>} nested />
+    )
+  }
+
+  if (Array.isArray(value)) {
+    return (
+      <div className="flex items-start gap-2 py-1">
+        <span className="text-text-secondary text-sm min-w-[180px] font-mono">{label}</span>
+        <div className="flex flex-wrap gap-1">
+          {value.map((item, i) => (
+            <span key={i} className="bg-bg-surface text-text-secondary text-xs font-mono px-2 py-0.5 rounded-sm border border-border-subtle">
+              {typeof item === 'object' ? JSON.stringify(item) : String(item)}
+            </span>
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  const display = typeof value === 'boolean'
+    ? (value ? 'true' : 'false')
+    : String(value)
+
+  return (
+    <div className="flex items-center gap-2 py-1">
+      <span className="text-text-secondary text-sm min-w-[180px] font-mono">{label}</span>
+      <span className={`text-sm font-mono ${typeof value === 'boolean' ? (value ? 'text-emerald' : 'text-text-tertiary') : 'text-text-primary'}`}>
+        {display}
+      </span>
+    </div>
+  )
+}
+
+function ConfigSection({ label, data, nested }: { label: string; data: Record<string, unknown>; nested?: boolean }) {
+  const [collapsed, setCollapsed] = useState(nested ?? false)
+
+  return (
+    <div className={nested ? 'ml-4 border-l border-border-subtle pl-3 my-1' : 'mb-4'}>
+      <button
+        onClick={() => setCollapsed(!collapsed)}
+        className="flex items-center gap-2 text-left w-full group"
+      >
+        <svg
+          className={`w-3 h-3 text-text-tertiary transition-transform ${collapsed ? '' : 'rotate-90'}`}
+          viewBox="0 0 16 16"
+          fill="currentColor"
+        >
+          <path d="M6 4l4 4-4 4z" />
+        </svg>
+        <span className={`font-semibold ${nested ? 'text-sm text-text-secondary' : 'text-md text-amber'}`}>
+          {label}
+        </span>
+        {collapsed && (
+          <span className="text-xs text-text-tertiary">
+            {Object.keys(data).length} fields
+          </span>
+        )}
+      </button>
+      {!collapsed && (
+        <div className={nested ? 'mt-1' : 'mt-2 ml-5'}>
+          {Object.entries(data).map(([k, v]) => (
+            <ConfigValue key={k} label={k} value={v} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default function ConfigViewer() {
+  const [config, setConfig] = useState<Record<string, unknown> | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    fetch('/api/config/gateway')
+      .then(r => r.json())
+      .then(data => {
+        if (data.error) {
+          setError(data.error)
+        } else {
+          setConfig(data)
+        }
+        setLoading(false)
+      })
+      .catch(err => {
+        setError(err.message)
+        setLoading(false)
+      })
+  }, [])
+
+  if (loading) {
+    return (
+      <div className="text-text-tertiary text-sm animate-pulse">Loading config...</div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="text-ao-red text-sm">Error: {error}</div>
+    )
+  }
+
+  if (!config) return null
+
+  // Order sections predictably
+  const orderedKeys = SECTION_ORDER.filter(k => k in config)
+  const extraKeys = Object.keys(config).filter(k => !SECTION_ORDER.includes(k))
+  const allKeys = [...orderedKeys, ...extraKeys]
+
+  return (
+    <div className="max-w-4xl">
+      <p className="text-text-tertiary text-xs mb-4 font-mono">
+        ~/.openclaw/openclaw.json — read-only
+      </p>
+      {allKeys.map(key => {
+        const value = config[key]
+        if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+          return <ConfigSection key={key} label={key} data={value as Record<string, unknown>} />
+        }
+        return <ConfigValue key={key} label={key} value={value} />
+      })}
+    </div>
+  )
+}

--- a/src/components/config/MemoryBrowser.tsx
+++ b/src/components/config/MemoryBrowser.tsx
@@ -1,0 +1,260 @@
+import { useState, useEffect } from 'react'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import { Light as SyntaxHighlighter } from 'react-syntax-highlighter'
+import json from 'react-syntax-highlighter/dist/esm/languages/hljs/json'
+import { atomOneDark } from 'react-syntax-highlighter/dist/esm/styles/hljs'
+
+SyntaxHighlighter.registerLanguage('json', json)
+
+const AGENTS = ['archimedes', 'aristotle', 'brainstorm', 'devops', 'herodotus', 'leo', 'platon', 'shared']
+
+interface FileList {
+  files: string[]
+  dailyDates: string[]
+}
+
+export default function MemoryBrowser() {
+  const [agent, setAgent] = useState('platon')
+  const [fileList, setFileList] = useState<FileList | null>(null)
+  const [selectedFile, setSelectedFile] = useState<string | null>(null)
+  const [selectedDate, setSelectedDate] = useState<string | null>(null)
+  const [content, setContent] = useState<string | null>(null)
+  const [contentType, setContentType] = useState<'markdown' | 'json'>('markdown')
+  const [loading, setLoading] = useState(false)
+  const [calendarMonth, setCalendarMonth] = useState(() => {
+    const now = new Date()
+    return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`
+  })
+
+  // Load file list when agent changes
+  useEffect(() => {
+    setFileList(null)
+    setSelectedFile(null)
+    setSelectedDate(null)
+    setContent(null)
+
+    fetch(`/api/memory/${agent}/files`)
+      .then(r => r.json())
+      .then(data => setFileList(data))
+      .catch(() => setFileList({ files: [], dailyDates: [] }))
+  }, [agent])
+
+  // Load file content
+  const loadFile = (file: string) => {
+    setSelectedFile(file)
+    setSelectedDate(null)
+    setLoading(true)
+    fetch(`/api/memory/${agent}/${file}`)
+      .then(r => r.json())
+      .then(data => {
+        setContent(data.content)
+        setContentType(data.type ?? 'markdown')
+        setLoading(false)
+      })
+      .catch(() => {
+        setContent(null)
+        setLoading(false)
+      })
+  }
+
+  // Load daily note
+  const loadDaily = (date: string) => {
+    setSelectedDate(date)
+    setSelectedFile(null)
+    setLoading(true)
+    fetch(`/api/memory/${agent}/daily/${date}`)
+      .then(r => r.json())
+      .then(data => {
+        setContent(data.content)
+        setContentType('markdown')
+        setLoading(false)
+      })
+      .catch(() => {
+        setContent(null)
+        setLoading(false)
+      })
+  }
+
+  // Calendar helpers
+  const [calYear, calMonth] = calendarMonth.split('-').map(Number)
+  const daysInMonth = new Date(calYear, calMonth, 0).getDate()
+  const firstDayOfWeek = new Date(calYear, calMonth - 1, 1).getDay()
+  const availableDates = new Set(fileList?.dailyDates ?? [])
+
+  const prevMonth = () => {
+    const d = new Date(calYear, calMonth - 2, 1)
+    setCalendarMonth(`${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`)
+  }
+  const nextMonth = () => {
+    const d = new Date(calYear, calMonth, 1)
+    setCalendarMonth(`${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`)
+  }
+
+  const mdFiles = (fileList?.files ?? []).filter(f => f.endsWith('.md'))
+  const jsonFiles = (fileList?.files ?? []).filter(f => f.endsWith('.json'))
+
+  return (
+    <div className="flex gap-6 h-[calc(100vh-160px)]">
+      {/* Left sidebar */}
+      <div className="w-64 shrink-0 overflow-y-auto space-y-4">
+        {/* Agent selector */}
+        <div>
+          <label className="text-xs text-text-tertiary font-semibold uppercase tracking-wider mb-1 block">
+            Agent
+          </label>
+          <select
+            value={agent}
+            onChange={e => setAgent(e.target.value)}
+            className="w-full bg-bg-void border border-border-default rounded-sm px-3 py-1.5 text-sm font-mono text-text-primary focus:outline-none focus:border-amber"
+          >
+            {AGENTS.map(a => (
+              <option key={a} value={a}>{a}</option>
+            ))}
+          </select>
+        </div>
+
+        {/* Markdown files */}
+        {mdFiles.length > 0 && (
+          <div>
+            <label className="text-xs text-text-tertiary font-semibold uppercase tracking-wider mb-1 block">
+              Files
+            </label>
+            <div className="space-y-0.5">
+              {mdFiles.map(f => (
+                <button
+                  key={f}
+                  onClick={() => loadFile(f)}
+                  className={`block w-full text-left px-2 py-1 rounded-sm text-sm font-mono transition-colors ${
+                    selectedFile === f
+                      ? 'bg-amber-subtle text-amber'
+                      : 'text-text-secondary hover:text-text-primary hover:bg-bg-hover'
+                  }`}
+                >
+                  {f}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* JSON files */}
+        {jsonFiles.length > 0 && (
+          <div>
+            <label className="text-xs text-text-tertiary font-semibold uppercase tracking-wider mb-1 block">
+              JSON
+            </label>
+            <div className="space-y-0.5">
+              {jsonFiles.map(f => (
+                <button
+                  key={f}
+                  onClick={() => loadFile(f)}
+                  className={`block w-full text-left px-2 py-1 rounded-sm text-sm font-mono transition-colors ${
+                    selectedFile === f
+                      ? 'bg-amber-subtle text-amber'
+                      : 'text-text-secondary hover:text-text-primary hover:bg-bg-hover'
+                  }`}
+                >
+                  {f}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Calendar */}
+        <div>
+          <label className="text-xs text-text-tertiary font-semibold uppercase tracking-wider mb-1 block">
+            Daily Notes
+          </label>
+          <div className="bg-bg-surface border border-border-subtle rounded-md p-2">
+            {/* Month nav */}
+            <div className="flex items-center justify-between mb-2">
+              <button onClick={prevMonth} className="text-text-tertiary hover:text-text-primary text-sm px-1">&lt;</button>
+              <span className="text-xs font-mono text-text-secondary">
+                {calYear}-{String(calMonth).padStart(2, '0')}
+              </span>
+              <button onClick={nextMonth} className="text-text-tertiary hover:text-text-primary text-sm px-1">&gt;</button>
+            </div>
+            {/* Day headers */}
+            <div className="grid grid-cols-7 gap-0 text-center mb-1">
+              {['Su','Mo','Tu','We','Th','Fr','Sa'].map(d => (
+                <span key={d} className="text-[10px] text-text-tertiary">{d}</span>
+              ))}
+            </div>
+            {/* Days */}
+            <div className="grid grid-cols-7 gap-0 text-center">
+              {Array.from({ length: firstDayOfWeek }).map((_, i) => (
+                <span key={`pad-${i}`} />
+              ))}
+              {Array.from({ length: daysInMonth }).map((_, i) => {
+                const day = i + 1
+                const dateStr = `${calYear}-${String(calMonth).padStart(2, '0')}-${String(day).padStart(2, '0')}`
+                const hasNote = availableDates.has(dateStr)
+                const isSelected = selectedDate === dateStr
+
+                return (
+                  <button
+                    key={day}
+                    disabled={!hasNote}
+                    onClick={() => hasNote && loadDaily(dateStr)}
+                    className={`text-xs py-0.5 rounded-sm transition-colors ${
+                      isSelected
+                        ? 'bg-amber text-text-inverse font-semibold'
+                        : hasNote
+                          ? 'text-emerald hover:bg-bg-hover cursor-pointer font-medium'
+                          : 'text-text-disabled cursor-default'
+                    }`}
+                  >
+                    {day}
+                  </button>
+                )
+              })}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Main content */}
+      <div className="flex-1 overflow-y-auto bg-bg-surface border border-border-subtle rounded-lg p-6">
+        {loading ? (
+          <div className="text-text-tertiary text-sm animate-pulse">Loading...</div>
+        ) : content ? (
+          <>
+            <div className="flex items-center gap-2 mb-4 pb-3 border-b border-border-subtle">
+              <span className="text-xs text-text-tertiary font-mono">
+                {agent}/{selectedFile ?? `daily/${selectedDate}.md`}
+              </span>
+            </div>
+            {contentType === 'json' ? (
+              <SyntaxHighlighter
+                language="json"
+                style={atomOneDark}
+                customStyle={{
+                  background: '#0C0B0A',
+                  borderRadius: '6px',
+                  padding: '16px',
+                  fontSize: '12px',
+                  lineHeight: '1.5',
+                }}
+              >
+                {(() => {
+                  try { return JSON.stringify(JSON.parse(content), null, 2) }
+                  catch { return content }
+                })()}
+              </SyntaxHighlighter>
+            ) : (
+              <div className="prose">
+                <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+              </div>
+            )}
+          </>
+        ) : (
+          <div className="flex items-center justify-center h-full text-text-tertiary text-sm">
+            Select a file or daily note to view
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/config/SkillsBrowser.tsx
+++ b/src/components/config/SkillsBrowser.tsx
@@ -1,0 +1,149 @@
+import { useState, useEffect } from 'react'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+
+interface Skill {
+  name: string
+  path: string
+  size: number
+  content: string
+}
+
+type SkillsData = Record<string, Skill[]>
+
+export default function SkillsBrowser() {
+  const [skills, setSkills] = useState<SkillsData | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [search, setSearch] = useState('')
+  const [expandedAgents, setExpandedAgents] = useState<Set<string>>(new Set())
+  const [selectedSkill, setSelectedSkill] = useState<Skill | null>(null)
+
+  useEffect(() => {
+    fetch('/api/skills')
+      .then(r => r.json())
+      .then(data => {
+        if (data.error) {
+          setError(data.error)
+        } else {
+          setSkills(data)
+          // Expand all agents by default
+          setExpandedAgents(new Set(Object.keys(data)))
+        }
+        setLoading(false)
+      })
+      .catch(err => {
+        setError(err.message)
+        setLoading(false)
+      })
+  }, [])
+
+  if (loading) {
+    return <div className="text-text-tertiary text-sm animate-pulse">Loading skills...</div>
+  }
+
+  if (error) {
+    return <div className="text-ao-red text-sm">Error: {error}</div>
+  }
+
+  if (!skills || Object.keys(skills).length === 0) {
+    return <div className="text-text-tertiary text-sm">No skills found.</div>
+  }
+
+  const toggleAgent = (agent: string) => {
+    setExpandedAgents(prev => {
+      const next = new Set(prev)
+      if (next.has(agent)) next.delete(agent)
+      else next.add(agent)
+      return next
+    })
+  }
+
+  const lowerSearch = search.toLowerCase()
+  const filteredSkills: SkillsData = {}
+  for (const [agent, skillList] of Object.entries(skills)) {
+    const filtered = skillList.filter(s =>
+      s.name.toLowerCase().includes(lowerSearch)
+    )
+    if (filtered.length > 0) filteredSkills[agent] = filtered
+  }
+
+  function formatSize(bytes: number): string {
+    if (bytes < 1024) return `${bytes} B`
+    return `${(bytes / 1024).toFixed(1)} KB`
+  }
+
+  return (
+    <div className="flex gap-6 h-[calc(100vh-160px)]">
+      {/* Left: tree */}
+      <div className="w-72 shrink-0 overflow-y-auto">
+        {/* Search */}
+        <input
+          type="text"
+          placeholder="Filter skills..."
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+          className="w-full bg-bg-void border border-border-default rounded-sm px-3 py-1.5 text-sm font-mono text-text-primary placeholder:text-text-tertiary focus:outline-none focus:border-amber mb-3"
+        />
+
+        {Object.entries(filteredSkills).map(([agent, skillList]) => (
+          <div key={agent} className="mb-2">
+            <button
+              onClick={() => toggleAgent(agent)}
+              className="flex items-center gap-2 w-full text-left py-1"
+            >
+              <svg
+                className={`w-3 h-3 text-text-tertiary transition-transform ${expandedAgents.has(agent) ? 'rotate-90' : ''}`}
+                viewBox="0 0 16 16"
+                fill="currentColor"
+              >
+                <path d="M6 4l4 4-4 4z" />
+              </svg>
+              <span className="text-sm font-semibold text-amber">{agent}</span>
+              <span className="text-xs text-text-tertiary">{skillList.length}</span>
+            </button>
+
+            {expandedAgents.has(agent) && (
+              <div className="ml-5 border-l border-border-subtle pl-2">
+                {skillList.map(skill => (
+                  <button
+                    key={skill.path}
+                    onClick={() => setSelectedSkill(skill)}
+                    className={`block w-full text-left py-1 px-2 rounded-sm text-sm transition-colors ${
+                      selectedSkill?.path === skill.path
+                        ? 'bg-amber-subtle text-amber'
+                        : 'text-text-secondary hover:text-text-primary hover:bg-bg-hover'
+                    }`}
+                  >
+                    <div className="font-mono">{skill.name}</div>
+                    <div className="text-xs text-text-tertiary">{formatSize(skill.size)}</div>
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+
+      {/* Right: content */}
+      <div className="flex-1 overflow-y-auto bg-bg-surface border border-border-subtle rounded-lg p-6">
+        {selectedSkill ? (
+          <>
+            <div className="flex items-center gap-3 mb-4 pb-3 border-b border-border-subtle">
+              <h2 className="text-md font-semibold text-text-primary">{selectedSkill.name}</h2>
+              <span className="text-xs text-text-tertiary font-mono">{formatSize(selectedSkill.size)}</span>
+            </div>
+            <p className="text-xs text-text-tertiary font-mono mb-4 break-all">{selectedSkill.path}</p>
+            <div className="prose">
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>{selectedSkill.content}</ReactMarkdown>
+            </div>
+          </>
+        ) : (
+          <div className="flex items-center justify-center h-full text-text-tertiary text-sm">
+            Select a skill to view its content
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/config/TeamManifest.tsx
+++ b/src/components/config/TeamManifest.tsx
@@ -1,0 +1,46 @@
+import { useState, useEffect } from 'react'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+
+export default function TeamManifest() {
+  const [content, setContent] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    fetch('/api/config/team-manifest')
+      .then(r => r.json())
+      .then(data => {
+        if (data.error) setError(data.error)
+        else setContent(data.content)
+        setLoading(false)
+      })
+      .catch(err => {
+        setError(err.message)
+        setLoading(false)
+      })
+  }, [])
+
+  if (loading) {
+    return <div className="text-text-tertiary text-sm animate-pulse">Loading team manifest...</div>
+  }
+
+  if (error) {
+    return <div className="text-ao-red text-sm">Error: {error}</div>
+  }
+
+  if (!content) {
+    return <div className="text-text-tertiary text-sm">No team manifest found.</div>
+  }
+
+  return (
+    <div className="max-w-4xl">
+      <p className="text-text-tertiary text-xs mb-4 font-mono">
+        ~/.openclaw/shared-memory/team-manifest.md
+      </p>
+      <div className="prose">
+        <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/ConfigPage.tsx
+++ b/src/pages/ConfigPage.tsx
@@ -1,8 +1,49 @@
+import { useState } from 'react'
+import ConfigViewer from '../components/config/ConfigViewer'
+import SkillsBrowser from '../components/config/SkillsBrowser'
+import MemoryBrowser from '../components/config/MemoryBrowser'
+import TeamManifest from '../components/config/TeamManifest'
+
+const TABS = ['Gateway', 'Team', 'Skills', 'Memory'] as const
+type Tab = (typeof TABS)[number]
+
 export default function ConfigPage() {
+  const [tab, setTab] = useState<Tab>('Gateway')
+
   return (
-    <div>
-      <h1 className="text-xl font-bold mb-4">Config & Settings</h1>
-      <p className="text-text-secondary">Config view — awaiting implementation.</p>
+    <div className="min-h-screen bg-bg-base text-text-primary font-ui">
+      {/* Header */}
+      <div className="border-b border-border-subtle px-6 py-3">
+        <h1 className="text-lg font-semibold">Config</h1>
+      </div>
+
+      {/* Tab bar */}
+      <div className="flex gap-0 border-b border-border-subtle px-6">
+        {TABS.map(t => (
+          <button
+            key={t}
+            onClick={() => setTab(t)}
+            className={`px-4 py-2 text-sm font-medium transition-colors relative ${
+              tab === t
+                ? 'text-amber'
+                : 'text-text-secondary hover:text-text-primary'
+            }`}
+          >
+            {t}
+            {tab === t && (
+              <span className="absolute bottom-0 left-0 right-0 h-[2px] bg-amber" />
+            )}
+          </button>
+        ))}
+      </div>
+
+      {/* Tab content */}
+      <div className="p-6">
+        {tab === 'Gateway' && <ConfigViewer />}
+        {tab === 'Team' && <TeamManifest />}
+        {tab === 'Skills' && <SkillsBrowser />}
+        {tab === 'Memory' && <MemoryBrowser />}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
Replaces PR #22. Rebased onto main — no Layout Shell regression.

Closes #9

## Changes
- `src/pages/ConfigPage.tsx`: populated stub (4-tab layout)
- `src/components/config/`: ConfigViewer, SkillsBrowser, MemoryBrowser, TeamManifest (all read-only)
- `server/api/{config,memory,skills}.js`: filesystem reads only, no writes
- `server/index.js`: /api/{config,memory,skills} registered
- Deps: remark-gfm, react-syntax-highlighter

## Review
- ✅ App.tsx / main.tsx untouched
- ✅ All read-only per spec
- ✅ No business logic reimplementation