### PR TITLE
feat: add cached rate-limit and status APIs

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "tsc -p tsconfig.app.json && vite build",
     "preview": "vite preview",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "test:server": "node --test server/lib/*.test.js",
     "typecheck": "tsc --noEmit -p tsconfig.app.json",
     "typecheck:server": "tsc --noEmit -p tsconfig.server.json",
     "start": "node server/index.js"

--- a/server/api/rate-limits.js
+++ b/server/api/rate-limits.js
@@ -1,0 +1,34 @@
+import { Router } from 'express'
+
+import {
+  readRateLimitResponse,
+  switchActiveProfile,
+} from '../lib/rate-limits.js'
+
+const router = Router()
+
+router.get('/', async (_req, res) => {
+  const payload = await readRateLimitResponse()
+  res.json(payload)
+})
+
+router.post('/switch', async (req, res) => {
+  const { to } = req.body ?? {}
+
+  if (typeof to !== 'string') {
+    return res.status(400).json({ ok: false, error: 'Missing "to" field' })
+  }
+
+  try {
+    const payload = await switchActiveProfile(to)
+    return res.json({ ok: true, active: payload.active })
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith('Unsupported profile:')) {
+      return res.status(400).json({ ok: false, error: error.message })
+    }
+
+    return res.status(500).json({ ok: false, error: 'Failed to switch profile' })
+  }
+})
+
+export default router

--- a/server/api/status.js
+++ b/server/api/status.js
@@ -1,124 +1,19 @@
-// GET /api/status — assemble GlobalStatus from ao-dashboard.js json + system vitals
 import { Router } from 'express'
-import { execFile } from 'child_process'
-import { promisify } from 'util'
-import { readFile } from 'fs/promises'
-import { homedir } from 'os'
-import { join } from 'path'
+import { createEmptyStatus, createStatusService } from '../lib/status.js'
 
-const exec = promisify(execFile)
-const router = Router()
+export function createStatusRouter(options = {}) {
+  const router = Router()
+  const statusService = createStatusService(options)
 
-let cachedResult = null
-let cachedAt = 0
-const CACHE_TTL_MS = 4000 // cache for 4s (poll is 5s)
-
-async function readCpuTemp() {
-  try {
-    const zones = ['/sys/class/thermal/thermal_zone0/temp']
-    for (const z of zones) {
-      const raw = await readFile(z, 'utf-8')
-      return Math.round(parseInt(raw, 10) / 1000)
+  router.get('/', async (_req, res) => {
+    try {
+      res.json(await statusService.getStatus())
+    } catch {
+      res.json(createEmptyStatus())
     }
-  } catch {
-    return null
-  }
+  })
+
+  return router
 }
 
-async function readCpuPercent() {
-  try {
-    const { stdout } = await exec('grep', ['-c', '^processor', '/proc/cpuinfo'])
-    const cpuCount = parseInt(stdout.trim(), 10) || 1
-    const load = await readFile('/proc/loadavg', 'utf-8')
-    const load1 = parseFloat(load.split(' ')[0])
-    return Math.min(100, Math.round((load1 / cpuCount) * 100))
-  } catch {
-    return null
-  }
-}
-
-async function fetchDashboardJson() {
-  const script = join(homedir(), 'clawd/scripts/ao-dashboard.js')
-  const { stdout } = await exec('node', [script, 'json'], { timeout: 3000 })
-  return JSON.parse(stdout)
-}
-
-async function assembleStatus() {
-  const now = Date.now()
-  if (cachedResult && (now - cachedAt) < CACHE_TTL_MS) {
-    return cachedResult
-  }
-
-  const [dashData, cpuTemp, cpuPercent] = await Promise.all([
-    fetchDashboardJson().catch(() => null),
-    readCpuTemp(),
-    readCpuPercent(),
-  ])
-
-  // Extract agent stats
-  const agents = dashData?.agents ?? []
-  const agentsAlive = agents.filter(a => a.state === 'active' || a.state === 'idle').length
-  const agentsTotal = agents.length
-
-  // Extract task stats from health or tasks array
-  const health = dashData?.health ?? {}
-  const tasks = dashData?.tasks ?? []
-  const activeTasks = health.active_tasks ?? tasks.filter(t => !['DONE', 'FAILED'].includes(t.state)).length
-  const blockedTasks = health.blocked_tasks ?? tasks.filter(t => t.state === 'BLOCKED').length
-  const stuckTasks = health.stale_tasks ?? tasks.filter(t => t.state === 'STUCK').length
-
-  // Gateway check: if ao-dashboard.js responded, gateway is up
-  const gatewayUp = dashData !== null
-
-  // Failed services — check systemd if available
-  let failedServices = 0
-  try {
-    const { stdout } = await exec('systemctl', ['--user', 'list-units', '--state=failed', '--no-legend', '--no-pager'], { timeout: 2000 })
-    failedServices = stdout.trim().split('\n').filter(l => l.trim()).length
-  } catch {
-    // not available or no failures
-  }
-
-  // Claude/Codex usage — read from status files if available
-  let claudeUsagePercent = null
-  let codexUsagePercent = null
-  try {
-    const ratesPath = join(homedir(), 'clawd/memory/rate-limits.json')
-    const ratesRaw = await readFile(ratesPath, 'utf-8')
-    const rates = JSON.parse(ratesRaw)
-    claudeUsagePercent = rates.claude_usage_percent ?? null
-    codexUsagePercent = rates.codex_usage_percent ?? null
-  } catch {
-    // not available
-  }
-
-  const result = {
-    gateway_up: gatewayUp,
-    agents_alive: agentsAlive,
-    agents_total: agentsTotal,
-    active_tasks: activeTasks,
-    blocked_tasks: blockedTasks,
-    stuck_tasks: stuckTasks,
-    failed_services: failedServices,
-    cpu_percent: cpuPercent,
-    cpu_temp: cpuTemp,
-    claude_usage_percent: claudeUsagePercent,
-    codex_usage_percent: codexUsagePercent,
-    timestamp: new Date().toISOString(),
-  }
-
-  cachedResult = result
-  cachedAt = now
-  return result
-}
-
-router.get('/', async (_req, res) => {
-  try {
-    const status = await assembleStatus()
-    res.json(status)
-  } catch (err) {
-    res.status(500).json({ error: 'Failed to assemble status', detail: err.message })
-  }
-})
-
-export default router
+export default createStatusRouter

--- a/server/index.js
+++ b/server/index.js
@@ -3,14 +3,20 @@
 import express from 'express'
 import { fileURLToPath } from 'url'
 import { join, dirname } from 'path'
+import rateLimitsRouter from './api/rate-limits.js'
 import tasksRouter from './api/tasks.js'
-import statusRouter from './api/status.js'
+import createStatusRouter from './api/status.js'
+import { createTtlCache } from './lib/ttl-cache.js'
+import { createVitalsMonitor } from './lib/vitals.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const app = express()
 const PORT = process.env.PORT ?? 3333
+const cache = createTtlCache({ maxEntries: 32 })
+const vitalsMonitor = createVitalsMonitor({ intervalMs: 10_000 })
 
 app.use(express.json())
+vitalsMonitor.start()
 
 // ─── Routes ───────────────────────────────────────────────────────────────────
 
@@ -19,7 +25,8 @@ app.get('/api/health', (_req, res) => {
 })
 
 app.use('/api/tasks', tasksRouter)
-app.use('/api/status', statusRouter)
+app.use('/api/rate-limits', rateLimitsRouter)
+app.use('/api/status', createStatusRouter({ cache, vitalsMonitor }))
 
 // Static client (prod)
 app.use(express.static(join(__dirname, '../dist/client')))

--- a/server/lib/rate-limits.js
+++ b/server/lib/rate-limits.js
@@ -1,0 +1,112 @@
+import { mkdir, readFile, stat, writeFile } from 'fs/promises'
+import { homedir } from 'os'
+import { join } from 'path'
+
+const STALE_THRESHOLD_MS = 5 * 60 * 1_000
+const ALLOWED_PROFILES = new Set(['yura', 'dima'])
+
+export const DEFAULT_RUNTIME_DIR = join(homedir(), 'clawd/runtime')
+
+function toNumber(value) {
+  const num = Number(value)
+  return Number.isFinite(num) ? num : 0
+}
+
+function getFallback() {
+  return { cached: false, stale: true, profiles: [] }
+}
+
+function normalizeProfile(raw = {}) {
+  return {
+    profile: typeof raw.profile === 'string' && raw.profile.trim() ? raw.profile : 'unknown',
+    tokens_used: toNumber(raw.tokens_used),
+    tokens_limit: toNumber(raw.tokens_limit),
+    requests_used: toNumber(raw.requests_used),
+    requests_limit: toNumber(raw.requests_limit),
+    reset_at: typeof raw.reset_at === 'string' ? raw.reset_at : '',
+    model: typeof raw.model === 'string' ? raw.model : '',
+  }
+}
+
+function normalizeProfiles(raw) {
+  const input = Array.isArray(raw)
+    ? raw
+    : Array.isArray(raw?.profiles)
+      ? raw.profiles
+      : []
+
+  return input
+    .filter((profile) => profile && typeof profile === 'object')
+    .map((profile) => normalizeProfile(profile))
+}
+
+function usageBucket(profile) {
+  const haystack = `${profile.profile} ${profile.model}`.toLowerCase()
+  return /(codex|gpt|o1|o3|o4|openai)/.test(haystack) ? 'codex' : 'claude'
+}
+
+function calculateUsagePercent(profiles, bucket) {
+  return profiles.reduce((maxPercent, profile) => {
+    if (usageBucket(profile) !== bucket || profile.tokens_limit <= 0) {
+      return maxPercent
+    }
+
+    const percent = Math.round((profile.tokens_used / profile.tokens_limit) * 100)
+    return Math.max(maxPercent, percent)
+  }, 0)
+}
+
+export async function readRateLimitResponse({
+  runtimeDir = DEFAULT_RUNTIME_DIR,
+  now = Date.now(),
+} = {}) {
+  const cacheFile = join(runtimeDir, 'rate-limit-cache.json')
+
+  try {
+    const fileStat = await stat(cacheFile)
+    if (now - fileStat.mtimeMs > STALE_THRESHOLD_MS) {
+      return getFallback()
+    }
+
+    const raw = JSON.parse(await readFile(cacheFile, 'utf8'))
+    return normalizeProfiles(raw)
+  } catch {
+    return getFallback()
+  }
+}
+
+export async function readRateLimitSnapshot(options = {}) {
+  const response = await readRateLimitResponse(options)
+  if (!Array.isArray(response)) {
+    return {
+      ...response,
+      claude_usage_percent: 0,
+      codex_usage_percent: 0,
+    }
+  }
+
+  return {
+    cached: true,
+    stale: false,
+    profiles: response,
+    claude_usage_percent: calculateUsagePercent(response, 'claude'),
+    codex_usage_percent: calculateUsagePercent(response, 'codex'),
+  }
+}
+
+export async function switchActiveProfile(to, { runtimeDir = DEFAULT_RUNTIME_DIR } = {}) {
+  if (!ALLOWED_PROFILES.has(to)) {
+    throw new Error(`Unsupported profile: ${to}`)
+  }
+
+  const profileFile = join(runtimeDir, 'active-profile.json')
+  const payload = {
+    active: to,
+    updated_at: new Date().toISOString(),
+  }
+
+  await mkdir(runtimeDir, { recursive: true })
+  await writeFile(profileFile, JSON.stringify(payload, null, 2) + '\n', 'utf8')
+
+  return payload
+}

--- a/server/lib/rate-limits.test.js
+++ b/server/lib/rate-limits.test.js
@@ -1,0 +1,114 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtemp, mkdir, readFile, writeFile, utimes } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+import {
+  readRateLimitResponse,
+  readRateLimitSnapshot,
+  switchActiveProfile,
+} from './rate-limits.js'
+
+async function makeRuntimeDir() {
+  const root = await mkdtemp(join(tmpdir(), 'ao-dashboard-rate-limits-'))
+  const runtimeDir = join(root, 'runtime')
+  await mkdir(runtimeDir, { recursive: true })
+  return runtimeDir
+}
+
+test('readRateLimitResponse returns a safe fallback when the cache file is missing', async () => {
+  const runtimeDir = await makeRuntimeDir()
+
+  const response = await readRateLimitResponse({ runtimeDir })
+
+  assert.deepEqual(response, { cached: false, stale: true, profiles: [] })
+})
+
+test('readRateLimitResponse returns profiles when the cache file is fresh', async () => {
+  const runtimeDir = await makeRuntimeDir()
+  const cacheFile = join(runtimeDir, 'rate-limit-cache.json')
+
+  await writeFile(cacheFile, JSON.stringify({
+    profiles: [
+      {
+        profile: 'yura',
+        tokens_used: 25,
+        tokens_limit: 100,
+        requests_used: 2,
+        requests_limit: 10,
+        reset_at: '2026-03-21T08:00:00.000Z',
+        model: 'claude-3-7-sonnet',
+      },
+    ],
+  }))
+
+  const response = await readRateLimitResponse({ runtimeDir })
+
+  assert.ok(Array.isArray(response))
+  assert.equal(response.length, 1)
+  assert.equal(response[0].profile, 'yura')
+})
+
+test('readRateLimitResponse returns a stale fallback when the cache is older than five minutes', async () => {
+  const runtimeDir = await makeRuntimeDir()
+  const cacheFile = join(runtimeDir, 'rate-limit-cache.json')
+
+  await writeFile(cacheFile, JSON.stringify({
+    profiles: [{ profile: 'dima', tokens_used: 5, tokens_limit: 10 }],
+  }))
+
+  const staleAt = new Date(Date.now() - 6 * 60 * 1_000)
+  await utimes(cacheFile, staleAt, staleAt)
+
+  const response = await readRateLimitResponse({ runtimeDir })
+
+  assert.deepEqual(response, { cached: false, stale: true, profiles: [] })
+})
+
+test('readRateLimitSnapshot derives claude and codex usage from the cache file', async () => {
+  const runtimeDir = await makeRuntimeDir()
+  const cacheFile = join(runtimeDir, 'rate-limit-cache.json')
+
+  await writeFile(cacheFile, JSON.stringify({
+    profiles: [
+      {
+        profile: 'yura',
+        tokens_used: 40,
+        tokens_limit: 100,
+        requests_used: 2,
+        requests_limit: 10,
+        reset_at: '2026-03-21T08:00:00.000Z',
+        model: 'claude-3-7-sonnet',
+      },
+      {
+        profile: 'codex',
+        tokens_used: 15,
+        tokens_limit: 20,
+        requests_used: 1,
+        requests_limit: 5,
+        reset_at: '2026-03-21T08:00:00.000Z',
+        model: 'gpt-4.1',
+      },
+    ],
+  }))
+
+  const snapshot = await readRateLimitSnapshot({ runtimeDir })
+
+  assert.equal(snapshot.claude_usage_percent, 40)
+  assert.equal(snapshot.codex_usage_percent, 75)
+  assert.equal(snapshot.cached, true)
+  assert.equal(snapshot.stale, false)
+  assert.equal(snapshot.profiles.length, 2)
+})
+
+test('switchActiveProfile writes active-profile.json', async () => {
+  const runtimeDir = await makeRuntimeDir()
+
+  const payload = await switchActiveProfile('dima', { runtimeDir })
+  const written = JSON.parse(await readFile(join(runtimeDir, 'active-profile.json'), 'utf8'))
+
+  assert.deepEqual(payload.active, 'dima')
+  assert.equal(written.active, 'dima')
+  assert.match(written.updated_at, /^\d{4}-\d{2}-\d{2}T/)
+})

--- a/server/lib/status.js
+++ b/server/lib/status.js
@@ -1,0 +1,192 @@
+import { execFile } from 'child_process'
+import { homedir } from 'os'
+import { join } from 'path'
+import { promisify } from 'util'
+
+import { readRateLimitSnapshot } from './rate-limits.js'
+
+const execFileAsync = promisify(execFile)
+
+const DEFAULT_AGENTS_TOTAL = 9
+const ALIVE_WINDOW_MINUTES = 5
+const DASHBOARD_SCRIPT = join(homedir(), 'clawd/scripts/ao-dashboard.js')
+const SERVICE_CACHE_TTL_MS = 10_000
+const VITALS_CACHE_TTL_MS = 10_000
+const MONITORED_SERVICES = [
+  'openclaw-gateway',
+  'mailbox-pump',
+  'stuck-detector',
+  'decision-timeout-sweeper',
+]
+
+const TERMINAL_TASK_STATES = new Set(['DONE', 'FAILED', 'CANCELLED', 'SUPERSEDED'])
+
+export function createEmptyStatus({ agentsTotal = DEFAULT_AGENTS_TOTAL } = {}) {
+  return {
+    gateway_up: false,
+    agents_alive: 0,
+    agents_total: agentsTotal,
+    active_tasks: 0,
+    blocked_tasks: 0,
+    stuck_tasks: 0,
+    failed_tasks: 0,
+    failed_services: 0,
+    cpu_percent: 0,
+    cpu_temp: 0,
+    claude_usage_percent: 0,
+    codex_usage_percent: 0,
+  }
+}
+
+export function buildTaskCounts(tasks = []) {
+  return tasks.reduce((counts, task) => {
+    const state = typeof task?.state === 'string' ? task.state.toUpperCase() : ''
+
+    if (state && !TERMINAL_TASK_STATES.has(state)) {
+      counts.active_tasks += 1
+    }
+
+    if (state === 'BLOCKED') {
+      counts.blocked_tasks += 1
+    }
+
+    if (state === 'STUCK') {
+      counts.stuck_tasks += 1
+    }
+
+    if (state === 'FAILED') {
+      counts.failed_tasks += 1
+    }
+
+    return counts
+  }, {
+    active_tasks: 0,
+    blocked_tasks: 0,
+    stuck_tasks: 0,
+    failed_tasks: 0,
+  })
+}
+
+export function countAliveAgents(agents = [], maxAgeMinutes = ALIVE_WINDOW_MINUTES) {
+  return agents.filter((agent) => {
+    if (typeof agent?.age === 'number') {
+      return agent.age < maxAgeMinutes
+    }
+
+    if (typeof agent?.updated_at === 'string') {
+      return Date.now() - new Date(agent.updated_at).getTime() < maxAgeMinutes * 60 * 1_000
+    }
+
+    return false
+  }).length
+}
+
+export function toGlobalStatus({
+  dashboard = null,
+  services = [],
+  vitals = {},
+  usage = {},
+  agentsTotal = DEFAULT_AGENTS_TOTAL,
+} = {}) {
+  const status = createEmptyStatus({ agentsTotal })
+  const taskCounts = buildTaskCounts(dashboard?.tasks ?? [])
+  const gateway = services.find((service) => service.name === 'openclaw-gateway')
+
+  return {
+    ...status,
+    agents_alive: countAliveAgents(dashboard?.agents ?? []),
+    ...taskCounts,
+    gateway_up: Boolean(gateway?.active),
+    failed_services: services.filter((service) => !service.active).length,
+    cpu_percent: Number.isFinite(vitals.cpu_percent) ? vitals.cpu_percent : 0,
+    cpu_temp: Number.isFinite(vitals.cpu_temp) ? vitals.cpu_temp : 0,
+    claude_usage_percent: Number.isFinite(usage.claude_usage_percent)
+      ? usage.claude_usage_percent
+      : 0,
+    codex_usage_percent: Number.isFinite(usage.codex_usage_percent)
+      ? usage.codex_usage_percent
+      : 0,
+  }
+}
+
+async function readIsActive(execImpl, args) {
+  try {
+    const { stdout } = await execImpl('systemctl', args, { timeout: 2_000 })
+    return stdout.trim() === 'active'
+  } catch (error) {
+    const stdout = typeof error?.stdout === 'string' ? error.stdout.trim() : ''
+    if (stdout) {
+      return stdout === 'active'
+    }
+    return null
+  }
+}
+
+async function loadServiceStatuses({
+  execImpl = execFileAsync,
+  serviceNames = MONITORED_SERVICES,
+} = {}) {
+  return Promise.all(serviceNames.map(async (name) => {
+    const userStatus = await readIsActive(execImpl, ['--user', 'is-active', name])
+    const active = userStatus ?? await readIsActive(execImpl, ['is-active', name]) ?? false
+    return { name, active }
+  }))
+}
+
+async function loadDashboardSnapshot({
+  execImpl = execFileAsync,
+  dashboardScript = DASHBOARD_SCRIPT,
+} = {}) {
+  try {
+    const { stdout } = await execImpl('node', [dashboardScript, 'json'], { timeout: 3_000 })
+    return JSON.parse(stdout)
+  } catch {
+    return null
+  }
+}
+
+async function getCached(cache, key, ttlMs, load) {
+  if (!cache) {
+    return load()
+  }
+
+  const existing = cache.get(key)
+  if (existing !== undefined) {
+    return existing
+  }
+
+  const value = await load()
+  cache.set(key, value, ttlMs)
+  return value
+}
+
+export function createStatusService({
+  cache = null,
+  vitalsMonitor = null,
+  execImpl = execFileAsync,
+  dashboardScript = DASHBOARD_SCRIPT,
+  runtimeDir,
+  serviceNames = MONITORED_SERVICES,
+  agentsTotal = DEFAULT_AGENTS_TOTAL,
+} = {}) {
+  return {
+    async getStatus() {
+      const [dashboard, services, vitals, usage] = await Promise.all([
+        loadDashboardSnapshot({ execImpl, dashboardScript }),
+        getCached(cache, 'status:services', SERVICE_CACHE_TTL_MS, () =>
+          loadServiceStatuses({ execImpl, serviceNames })),
+        getCached(cache, 'status:vitals', VITALS_CACHE_TTL_MS, async () =>
+          vitalsMonitor?.getSnapshot?.() ?? { cpu_percent: 0, cpu_temp: 0 }),
+        readRateLimitSnapshot({ runtimeDir }),
+      ])
+
+      return toGlobalStatus({
+        dashboard,
+        services,
+        vitals,
+        usage,
+        agentsTotal,
+      })
+    },
+  }
+}

--- a/server/lib/status.test.js
+++ b/server/lib/status.test.js
@@ -1,0 +1,85 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  buildTaskCounts,
+  countAliveAgents,
+  createEmptyStatus,
+  toGlobalStatus,
+} from './status.js'
+
+test('buildTaskCounts separates active, blocked, stuck, and failed tasks', () => {
+  const counts = buildTaskCounts([
+    { state: 'EXECUTION' },
+    { state: 'BLOCKED' },
+    { state: 'STUCK' },
+    { state: 'FAILED' },
+    { state: 'DONE' },
+  ])
+
+  assert.deepEqual(counts, {
+    active_tasks: 3,
+    blocked_tasks: 1,
+    stuck_tasks: 1,
+    failed_tasks: 1,
+  })
+})
+
+test('countAliveAgents uses a five-minute heartbeat window', () => {
+  const alive = countAliveAgents([
+    { age: 0 },
+    { age: 4 },
+    { age: 5 },
+    { age: 9 },
+  ])
+
+  assert.equal(alive, 2)
+})
+
+test('toGlobalStatus always returns the authoritative 12-field payload', () => {
+  const status = toGlobalStatus({
+    dashboard: {
+      tasks: [{ state: 'FAILED' }, { state: 'BLOCKED' }, { state: 'EXECUTION' }],
+      agents: [{ age: 1 }, { age: 6 }],
+    },
+    services: [
+      { name: 'openclaw-gateway', active: true },
+      { name: 'mailbox-pump', active: false },
+    ],
+    vitals: { cpu_percent: 12, cpu_temp: 64 },
+    usage: { claude_usage_percent: 55, codex_usage_percent: 8 },
+    agentsTotal: 9,
+  })
+
+  assert.deepEqual(status, {
+    gateway_up: true,
+    agents_alive: 1,
+    agents_total: 9,
+    active_tasks: 2,
+    blocked_tasks: 1,
+    stuck_tasks: 0,
+    failed_tasks: 1,
+    failed_services: 1,
+    cpu_percent: 12,
+    cpu_temp: 64,
+    claude_usage_percent: 55,
+    codex_usage_percent: 8,
+  })
+})
+
+test('createEmptyStatus fills every field with non-null defaults', () => {
+  assert.deepEqual(createEmptyStatus(), {
+    gateway_up: false,
+    agents_alive: 0,
+    agents_total: 9,
+    active_tasks: 0,
+    blocked_tasks: 0,
+    stuck_tasks: 0,
+    failed_tasks: 0,
+    failed_services: 0,
+    cpu_percent: 0,
+    cpu_temp: 0,
+    claude_usage_percent: 0,
+    codex_usage_percent: 0,
+  })
+})

--- a/server/lib/ttl-cache.js
+++ b/server/lib/ttl-cache.js
@@ -1,0 +1,57 @@
+export function createTtlCache({ maxEntries = 64, now = () => Date.now() } = {}) {
+  const store = new Map()
+
+  function evictExpired(key, entry) {
+    if (!entry) {
+      return undefined
+    }
+
+    if (now() > entry.expiresAt) {
+      store.delete(key)
+      return undefined
+    }
+
+    return entry
+  }
+
+  return {
+    get(key) {
+      const entry = evictExpired(key, store.get(key))
+      if (!entry) {
+        return undefined
+      }
+
+      store.delete(key)
+      store.set(key, entry)
+      return entry.value
+    },
+
+    set(key, value, ttlMs) {
+      const expiresAt = now() + ttlMs
+
+      if (store.has(key)) {
+        store.delete(key)
+      }
+
+      store.set(key, { value, expiresAt })
+
+      while (store.size > maxEntries) {
+        const oldestKey = store.keys().next().value
+        if (oldestKey === undefined) {
+          break
+        }
+        store.delete(oldestKey)
+      }
+
+      return value
+    },
+
+    delete(key) {
+      store.delete(key)
+    },
+
+    clear() {
+      store.clear()
+    },
+  }
+}

--- a/server/lib/ttl-cache.test.js
+++ b/server/lib/ttl-cache.test.js
@@ -1,0 +1,29 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { createTtlCache } from './ttl-cache.js'
+
+test('ttl cache expires entries after their ttl', () => {
+  let now = 1_000
+  const cache = createTtlCache({ now: () => now })
+
+  cache.set('services', { ok: true }, 50)
+  assert.deepEqual(cache.get('services'), { ok: true })
+
+  now = 1_060
+  assert.equal(cache.get('services'), undefined)
+})
+
+test('ttl cache refreshes recency on get and evicts the oldest entry', () => {
+  const cache = createTtlCache({ maxEntries: 2 })
+
+  cache.set('a', 1, 1_000)
+  cache.set('b', 2, 1_000)
+  assert.equal(cache.get('a'), 1)
+
+  cache.set('c', 3, 1_000)
+
+  assert.equal(cache.get('a'), 1)
+  assert.equal(cache.get('b'), undefined)
+  assert.equal(cache.get('c'), 3)
+})

--- a/server/lib/vitals.js
+++ b/server/lib/vitals.js
@@ -1,0 +1,120 @@
+import { readFile, readdir } from 'fs/promises'
+import { join } from 'path'
+
+function parseCpuTimes(raw) {
+  const [line = ''] = raw.split('\n')
+  const values = line
+    .replace(/^cpu\s+/, '')
+    .trim()
+    .split(/\s+/)
+    .map((value) => Number(value))
+
+  const idle = (values[3] ?? 0) + (values[4] ?? 0)
+  const total = values.reduce((sum, value) => sum + (Number.isFinite(value) ? value : 0), 0)
+
+  return { idle, total }
+}
+
+export function calculateCpuPercent(previous, current) {
+  const idleDelta = current.idle - previous.idle
+  const totalDelta = current.total - previous.total
+
+  if (totalDelta <= 0) {
+    return 0
+  }
+
+  return Math.max(0, Math.min(100, Math.round(((totalDelta - idleDelta) / totalDelta) * 100)))
+}
+
+async function readCpuTimes() {
+  try {
+    const raw = await readFile('/proc/stat', 'utf8')
+    return parseCpuTimes(raw)
+  } catch {
+    return { idle: 0, total: 0 }
+  }
+}
+
+async function readCpuTemp() {
+  try {
+    const zones = await readdir('/sys/class/thermal')
+    const temps = await Promise.all(
+      zones
+        .filter((zone) => zone.startsWith('thermal_zone'))
+        .map(async (zone) => {
+          try {
+            const raw = await readFile(join('/sys/class/thermal', zone, 'temp'), 'utf8')
+            return Math.round(parseInt(raw, 10) / 1_000)
+          } catch {
+            return 0
+          }
+        }),
+    )
+
+    return temps.reduce((maxTemp, value) => Math.max(maxTemp, value), 0)
+  } catch {
+    return 0
+  }
+}
+
+export function createVitalsMonitor({
+  intervalMs = 10_000,
+  readCpuTimesImpl = readCpuTimes,
+  readCpuTempImpl = readCpuTemp,
+} = {}) {
+  let snapshot = { cpu_percent: 0, cpu_temp: 0 }
+  let previous = null
+  let timer = null
+
+  async function update() {
+    const [current, cpuTemp] = await Promise.all([
+      readCpuTimesImpl(),
+      readCpuTempImpl(),
+    ])
+
+    if (previous) {
+      snapshot = {
+        cpu_percent: calculateCpuPercent(previous, current),
+        cpu_temp: Number.isFinite(cpuTemp) ? cpuTemp : 0,
+      }
+    } else {
+      snapshot = {
+        cpu_percent: snapshot.cpu_percent,
+        cpu_temp: Number.isFinite(cpuTemp) ? cpuTemp : 0,
+      }
+    }
+
+    previous = current
+    return snapshot
+  }
+
+  return {
+    getSnapshot() {
+      return { ...snapshot }
+    },
+
+    async update() {
+      return update()
+    },
+
+    start() {
+      if (timer) {
+        return timer
+      }
+
+      void update()
+      timer = setInterval(() => {
+        void update()
+      }, intervalMs)
+      timer.unref?.()
+      return timer
+    },
+
+    stop() {
+      if (timer) {
+        clearInterval(timer)
+        timer = null
+      }
+    },
+  }
+}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -23,7 +23,7 @@ const navItems: NavItem[] = [
     icon: '⚡',
     badge: (s) => {
       if (!s) return null
-      const count = s.blocked_tasks + s.stuck_tasks
+      const count = s.blocked_tasks + s.stuck_tasks + s.failed_tasks
       return count > 0 ? count : null
     },
     badgeColor: 'red',

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -89,6 +89,19 @@ export default function TopBar({ status }: TopBarProps) {
         </span>
       </button>
 
+      <button
+        onClick={() => navigate('/')}
+        className="flex items-center gap-1.5 hover:bg-bg-hover rounded px-1.5 py-1 transition-colors"
+      >
+        <span
+          className={`text-xs ${
+            status && status.failed_tasks > 0 ? 'text-accent-red' : 'text-text-secondary'
+          }`}
+        >
+          Failed {status?.failed_tasks ?? '—'}
+        </span>
+      </button>
+
       <div className="flex-1" />
 
       {/* CPU */}

--- a/src/components/system/UsageTracker.tsx
+++ b/src/components/system/UsageTracker.tsx
@@ -1,0 +1,118 @@
+import { usePolling } from '../../hooks/usePolling'
+import { getRateLimits } from '../../lib/api'
+import type { RateLimitFallback, RateLimitProfile, RateLimitsApiResponse } from '../../lib/types'
+
+function normalizeResponse(data: RateLimitsApiResponse | null): RateLimitFallback | {
+  cached: true
+  stale: false
+  profiles: RateLimitProfile[]
+} | null {
+  if (!data) {
+    return null
+  }
+
+  if (Array.isArray(data)) {
+    return {
+      cached: true,
+      stale: false,
+      profiles: data,
+    }
+  }
+
+  return data
+}
+
+function percent(used: number, limit: number) {
+  if (limit <= 0) {
+    return 0
+  }
+
+  return Math.round((used / limit) * 100)
+}
+
+export default function UsageTracker() {
+  const { data } = usePolling(getRateLimits, 10_000)
+  const rateLimits = normalizeResponse(data)
+
+  if (!rateLimits) {
+    return (
+      <section className="bg-bg-surface border border-border-subtle rounded-xl p-4">
+        <h2 className="text-sm font-semibold mb-2">Gateway Rate Limits</h2>
+        <p className="text-sm text-text-secondary">Loading gateway cache…</p>
+      </section>
+    )
+  }
+
+  if (!rateLimits.cached || rateLimits.profiles.length === 0) {
+    return (
+      <section className="bg-bg-surface border border-border-subtle rounded-xl p-4">
+        <h2 className="text-sm font-semibold mb-2">Gateway Rate Limits</h2>
+        <p className="text-sm text-text-secondary">
+          Cache unavailable{rateLimits.stale ? ' or stale' : ''}. The dashboard is waiting for the
+          gateway to write a fresh rate-limit snapshot.
+        </p>
+      </section>
+    )
+  }
+
+  return (
+    <section className="bg-bg-surface border border-border-subtle rounded-xl p-4">
+      <div className="flex items-center justify-between gap-4 mb-4">
+        <h2 className="text-sm font-semibold">Gateway Rate Limits</h2>
+        <span className="text-xs text-text-secondary">
+          {rateLimits.stale ? 'Stale cache' : 'Live cache'}
+        </span>
+      </div>
+
+      <div className="space-y-3">
+        {rateLimits.profiles.map((profile) => {
+          const tokenPercent = percent(profile.tokens_used, profile.tokens_limit)
+          const requestPercent = percent(profile.requests_used, profile.requests_limit)
+
+          return (
+            <article
+              key={`${profile.profile}:${profile.model}`}
+              className="bg-bg-elevated border border-border-subtle rounded-lg p-3"
+            >
+              <div className="flex items-center justify-between gap-4 mb-2">
+                <div>
+                  <h3 className="text-sm font-medium">{profile.profile}</h3>
+                  <p className="text-xs text-text-secondary">{profile.model || 'Model unknown'}</p>
+                </div>
+                <span className="text-xs text-text-tertiary">{profile.reset_at || 'No reset time'}</span>
+              </div>
+
+              <div className="space-y-2">
+                <div>
+                  <div className="flex items-center justify-between text-xs text-text-secondary mb-1">
+                    <span>Tokens</span>
+                    <span>{profile.tokens_used}/{profile.tokens_limit}</span>
+                  </div>
+                  <div className="h-2 rounded-full bg-bg-base overflow-hidden">
+                    <div
+                      className="h-full bg-status-healthy rounded-full"
+                      style={{ width: `${Math.min(tokenPercent, 100)}%` }}
+                    />
+                  </div>
+                </div>
+
+                <div>
+                  <div className="flex items-center justify-between text-xs text-text-secondary mb-1">
+                    <span>Requests</span>
+                    <span>{profile.requests_used}/{profile.requests_limit}</span>
+                  </div>
+                  <div className="h-2 rounded-full bg-bg-base overflow-hidden">
+                    <div
+                      className="h-full bg-accent-amber rounded-full"
+                      style={{ width: `${Math.min(requestPercent, 100)}%` }}
+                    />
+                  </div>
+                </div>
+              </div>
+            </article>
+          )
+        })}
+      </div>
+    </section>
+  )
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,4 +1,14 @@
-import type { Task, TaskEvent, TaskDecision, TaskContract, TransitionError, PipelineState, GlobalStatus, TaskListItem } from './types';
+import type {
+  Task,
+  TaskEvent,
+  TaskDecision,
+  TaskContract,
+  TransitionError,
+  PipelineState,
+  GlobalStatus,
+  TaskListItem,
+  RateLimitsApiResponse,
+} from './types';
 
 const BASE = '/api';
 
@@ -22,6 +32,17 @@ async function fetchJson<T>(path: string): Promise<T> {
 
 export function getStatus(): Promise<GlobalStatus> {
   return fetchJson<GlobalStatus>('/status');
+}
+
+export function getRateLimits(): Promise<RateLimitsApiResponse> {
+  return fetchJson<RateLimitsApiResponse>('/rate-limits');
+}
+
+export function switchRateLimitProfile(to: 'yura' | 'dima'): Promise<{ ok: true; active: string }> {
+  return request('/rate-limits/switch', {
+    method: 'POST',
+    body: JSON.stringify({ to }),
+  });
 }
 
 // ─── Response shapes from the backend ──────────────────────────────────────

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -6,13 +6,31 @@ export interface GlobalStatus {
   active_tasks: number
   blocked_tasks: number
   stuck_tasks: number
+  failed_tasks: number
   failed_services: number
-  cpu_percent: number | null
-  cpu_temp: number | null
-  claude_usage_percent: number | null
-  codex_usage_percent: number | null
-  timestamp: string
+  cpu_percent: number
+  cpu_temp: number
+  claude_usage_percent: number
+  codex_usage_percent: number
 }
+
+export interface RateLimitProfile {
+  profile: string
+  tokens_used: number
+  tokens_limit: number
+  requests_used: number
+  requests_limit: number
+  reset_at: string
+  model: string
+}
+
+export interface RateLimitFallback {
+  cached: false
+  stale: true
+  profiles: RateLimitProfile[]
+}
+
+export type RateLimitsApiResponse = RateLimitProfile[] | RateLimitFallback
 
 export const PIPELINE_STATES = [
   'INTAKE', 'CONTEXT', 'RESEARCH', 'DESIGN', 'PLANNING', 'SETUP',

--- a/src/pages/ConfigPage.tsx
+++ b/src/pages/ConfigPage.tsx
@@ -1,8 +1,17 @@
+import UsageTracker from '../components/system/UsageTracker'
+
 export default function ConfigPage() {
   return (
-    <div>
-      <h1 className="text-xl font-bold mb-4">Config & Settings</h1>
-      <p className="text-text-secondary">Config view — awaiting implementation.</p>
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-xl font-bold mb-2">Config & Settings</h1>
+        <p className="text-text-secondary">
+          Profile switching is exposed server-side at <code>/api/rate-limits/switch</code>.
+          The live gateway cache is summarized below.
+        </p>
+      </div>
+
+      <UsageTracker />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add a real `/api/rate-limits` reader plus `POST /api/rate-limits/switch`, backed by `~/clawd/runtime/*.json`
- replace `/api/status` with an authoritative aggregator that caches service/vitals reads server-side and pulls live task/agent data from `ao-dashboard.js`
- update the dashboard client to consume the new status/rate-limit payloads, including a UsageTracker view and failed-task badges

Closes #11.

## Test Plan
- `npm run lint`
- `npm run typecheck`
- `npm run test:server`
- `npm run build`
- `curl http://localhost:3334/api/status` → 12 fields, non-null values
- `curl http://localhost:3334/api/rate-limits` → stale fallback when cache missing/stale
- `curl -X POST http://localhost:3334/api/rate-limits/switch -H 'Content-Type: application/json' -d '{"to":"dima"}'`
- `curl -w '%{time_total}' http://localhost:3334/api/status` x10 → all <0.03s in local verification

## Notes
- Port `3333` was already occupied by another local service in this environment, so live curl verification used `PORT=3334 node server/index.js`.
- `npm run typecheck:server` is still broken on `main` because `tsconfig.server.json` has no JS inputs; CI does not run that script.
