### PR TITLE
feat(#10): UX Polish — Toast + ErrorBoundary + Skeleton + EmptyState

### DIFF
--- a/docs/plans/2026-03-21-ux-polish.md
+++ b/docs/plans/2026-03-21-ux-polish.md
@@ -1,0 +1,466 @@
+# UX Polish Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add Toast notifications, ErrorBoundary, Skeleton shimmer, EmptyState, and useApi hook across ao-dashboard.
+
+**Architecture:** New reusable UI primitives (Skeleton, EmptyState, ErrorBoundary) + context-based Toast system + generic useApi hook; apply to all existing data-fetching components.
+
+**Tech Stack:** React 18 (class component for ErrorBoundary), Context API for Toast, Tailwind CSS design tokens, Vitest + Testing Library.
+
+---
+
+### Key Codebase Facts
+- `tailwind.config.js` already has `shimmer` keyframe → `animate-skeleton` and `slideInRight` → `animate-slide-in-right`. NO config changes needed.
+- Color tokens: use `text-emerald`, `border-red`, `bg-amber-subtle` (NOT `accent-emerald` etc. — those don't exist in tailwind config)
+- `accent.amber` exists → `text-accent-amber`, `border-accent-amber` work
+- Routes are in `src/main.tsx` (not App.tsx) — wrap ErrorBoundary and ToastProvider there
+- tsconfig: `noUnusedLocals: true`, `noUnusedParameters: true` — no dead code
+- No @testing-library/user-event — use `fireEvent` from @testing-library/react
+
+---
+
+### Task 1: src/hooks/useToast.ts (new)
+
+**Files:**
+- Create: `src/hooks/useToast.ts`
+
+Full context + provider + hook:
+- `ToastVariant`: `'success' | 'warning' | 'error' | 'info'`
+- `Toast`: `{ id: string, message: string, variant: ToastVariant, dismissible?: boolean, action?: { label: string; fn: () => void } }`
+- Auto-dismiss timers: success/info = 5000ms, warning = 8000ms, error = never
+- Max 5 toasts; 6th push replaces oldest
+- `ToastContext` + `ToastProvider` component
+- `useToast()` returns `{ push(msg, variant, opts?), dismiss(id), dismissAll() }`
+
+```tsx
+import { createContext, useContext, useState, useRef, useCallback, ReactNode } from 'react'
+
+export type ToastVariant = 'success' | 'warning' | 'error' | 'info'
+
+export interface Toast {
+  id: string
+  message: string
+  variant: ToastVariant
+  dismissible?: boolean
+  action?: { label: string; fn: () => void }
+}
+
+interface ToastContextValue {
+  toasts: Toast[]
+  push: (message: string, variant: ToastVariant, options?: Partial<Omit<Toast, 'id' | 'message' | 'variant'>>) => void
+  dismiss: (id: string) => void
+  dismissAll: () => void
+}
+
+const ToastContext = createContext<ToastContextValue | null>(null)
+
+const AUTO_DISMISS_MS: Record<ToastVariant, number | null> = {
+  success: 5000,
+  info: 5000,
+  warning: 8000,
+  error: null,
+}
+const MAX_TOASTS = 5
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<Toast[]>([])
+  const timers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map())
+
+  const dismiss = useCallback((id: string) => {
+    const t = timers.current.get(id)
+    if (t) { clearTimeout(t); timers.current.delete(id) }
+    setToasts((prev) => prev.filter((toast) => toast.id !== id))
+  }, [])
+
+  const push = useCallback((
+    message: string,
+    variant: ToastVariant,
+    options?: Partial<Omit<Toast, 'id' | 'message' | 'variant'>>
+  ) => {
+    const id = `${Date.now()}-${Math.random()}`
+    const toast: Toast = { id, message, variant, dismissible: true, ...options }
+    setToasts((prev) => {
+      const next = [...prev, toast]
+      if (next.length > MAX_TOASTS) {
+        const removed = next.shift()!
+        const t = timers.current.get(removed.id)
+        if (t) { clearTimeout(t); timers.current.delete(removed.id) }
+      }
+      return next
+    })
+    const delay = AUTO_DISMISS_MS[variant]
+    if (delay !== null) {
+      const t = setTimeout(() => dismiss(id), delay)
+      timers.current.set(id, t)
+    }
+  }, [dismiss])
+
+  const dismissAll = useCallback(() => {
+    timers.current.forEach((t) => clearTimeout(t))
+    timers.current.clear()
+    setToasts([])
+  }, [])
+
+  return (
+    <ToastContext.Provider value={{ toasts, push, dismiss, dismissAll }}>
+      {children}
+    </ToastContext.Provider>
+  )
+}
+
+export function useToast(): ToastContextValue {
+  const ctx = useContext(ToastContext)
+  if (!ctx) throw new Error('useToast must be used within ToastProvider')
+  return ctx
+}
+```
+
+---
+
+### Task 2: src/components/layout/Toast.tsx (new)
+
+**Files:**
+- Create: `src/components/layout/Toast.tsx`
+
+Fixed bottom-right stack, z-50, max 5. Variant styles with left border + icon:
+
+```tsx
+import { useToast } from '../../hooks/useToast'
+import type { Toast, ToastVariant } from '../../hooks/useToast'
+
+const VARIANT_STYLES: Record<ToastVariant, { border: string; icon: string; bg: string }> = {
+  success: { border: 'border-l-4 border-emerald', icon: '✓', bg: 'bg-bg-elevated' },
+  warning: { border: 'border-l-4 border-amber', icon: '⚠', bg: 'bg-bg-elevated' },
+  error:   { border: 'border-l-4 border-red',   icon: '✕', bg: 'bg-bg-elevated' },
+  info:    { border: 'border-l-4 border-blue',  icon: 'ℹ', bg: 'bg-bg-elevated' },
+}
+
+function ToastItem({ toast }: { toast: Toast }) {
+  const { dismiss } = useToast()
+  const { border, icon, bg } = VARIANT_STYLES[toast.variant]
+  return (
+    <div
+      role="alert"
+      className={`flex items-start gap-3 px-4 py-3 rounded-md shadow-lg text-text-primary text-sm animate-slide-in-right ${border} ${bg}`}
+    >
+      <span className="shrink-0 font-mono">{icon}</span>
+      <span className="flex-1">{toast.message}</span>
+      {toast.action && (
+        <button onClick={toast.action.fn} className="text-xs text-accent-amber hover:underline shrink-0">
+          {toast.action.label}
+        </button>
+      )}
+      {toast.dismissible !== false && (
+        <button onClick={() => dismiss(toast.id)} aria-label="Dismiss" className="shrink-0 text-text-tertiary hover:text-text-primary">
+          ×
+        </button>
+      )}
+    </div>
+  )
+}
+
+export default function ToastStack() {
+  const { toasts } = useToast()
+  if (toasts.length === 0) return null
+  return (
+    <div className="fixed bottom-4 right-4 z-50 flex flex-col gap-2 max-w-sm w-full">
+      {toasts.map((t) => <ToastItem key={t.id} toast={t} />)}
+    </div>
+  )
+}
+```
+
+---
+
+### Task 3: src/components/ui/Skeleton.tsx (new)
+
+**Files:**
+- Create: `src/components/ui/Skeleton.tsx`
+
+```tsx
+interface SkeletonProps {
+  className?: string
+  width?: string
+  height?: string
+  lines?: number
+}
+
+export default function Skeleton({ className = '', width, height, lines }: SkeletonProps) {
+  const style: React.CSSProperties = {}
+  if (width) style.width = width
+  if (height) style.height = height
+
+  if (lines && lines > 1) {
+    return (
+      <div className="space-y-2">
+        {Array.from({ length: lines }).map((_, i) => (
+          <div
+            key={i}
+            style={style}
+            className={`animate-skeleton rounded bg-gradient-to-r from-bg-surface via-bg-elevated to-bg-surface bg-[length:200%_100%] ${className}`}
+          />
+        ))}
+      </div>
+    )
+  }
+
+  return (
+    <div
+      style={style}
+      className={`animate-skeleton rounded bg-gradient-to-r from-bg-surface via-bg-elevated to-bg-surface bg-[length:200%_100%] ${className}`}
+    />
+  )
+}
+```
+
+---
+
+### Task 4: src/components/ui/EmptyState.tsx (new)
+
+**Files:**
+- Create: `src/components/ui/EmptyState.tsx`
+
+```tsx
+interface EmptyStateProps {
+  icon: string
+  title: string
+  description?: string
+  action?: { label: string; onClick: () => void }
+}
+
+export default function EmptyState({ icon, title, description, action }: EmptyStateProps) {
+  return (
+    <div className="flex flex-col items-center justify-center p-8 bg-bg-surface border border-border-subtle rounded-lg text-center">
+      <span className="text-2xl mb-3 text-text-tertiary">{icon}</span>
+      <p className="text-sm font-medium text-text-secondary">{title}</p>
+      {description && <p className="text-xs text-text-tertiary mt-1">{description}</p>}
+      {action && (
+        <button
+          onClick={action.onClick}
+          className="mt-4 px-3 py-1.5 text-xs rounded-sm border border-border-default text-text-secondary hover:bg-bg-hover hover:text-text-primary transition-colors"
+        >
+          {action.label}
+        </button>
+      )}
+    </div>
+  )
+}
+```
+
+---
+
+### Task 5: src/components/layout/ErrorBoundary.tsx (new)
+
+**Files:**
+- Create: `src/components/layout/ErrorBoundary.tsx`
+
+React class component (required for error boundaries). Also exports `InlineErrorCard` functional component.
+
+```tsx
+import { Component, ReactNode } from 'react'
+
+interface ErrorBoundaryProps {
+  children: ReactNode
+  fallback?: ReactNode
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean
+  message: string
+}
+
+export default class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props)
+    this.state = { hasError: false, message: '' }
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, message: error.message }
+  }
+
+  override render() {
+    if (this.state.hasError) {
+      if (this.props.fallback) return this.props.fallback
+      return (
+        <div className="m-4 p-4 rounded-lg bg-red-subtle border border-red-dim text-text-primary">
+          <p className="text-sm font-medium mb-2">Something went wrong</p>
+          <p className="text-xs text-text-secondary mb-4 font-mono">{this.state.message}</p>
+          <button
+            onClick={() => window.location.reload()}
+            className="px-3 py-1.5 text-xs rounded-sm border border-border-default text-text-secondary hover:bg-bg-hover transition-colors"
+          >
+            Retry
+          </button>
+        </div>
+      )
+    }
+    return this.props.children
+  }
+}
+
+interface InlineErrorCardProps {
+  message: string
+  onRetry?: () => void
+}
+
+export function InlineErrorCard({ message, onRetry }: InlineErrorCardProps) {
+  return (
+    <div className="p-3 rounded-md bg-red-subtle border border-red-dim text-text-primary text-sm">
+      <span className="text-xs font-mono">{message}</span>
+      {onRetry && (
+        <button onClick={onRetry} className="ml-3 text-xs text-accent-amber hover:underline">
+          Retry
+        </button>
+      )}
+    </div>
+  )
+}
+```
+
+---
+
+### Task 6: src/hooks/useApi.ts (new)
+
+**Files:**
+- Create: `src/hooks/useApi.ts`
+
+Generic polling hook. `loading=true` only on first fetch. Subsequent polls keep `loading=false`. Error triggers toast.
+
+```tsx
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { useToast } from './useToast'
+
+interface UseApiResult<T> {
+  data: T | null
+  loading: boolean
+  error: string | null
+  refetch: () => void
+}
+
+export function useApi<T>(url: string, intervalMs?: number): UseApiResult<T> {
+  const [data, setData] = useState<T | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const { push } = useToast()
+  const isFirstFetch = useRef(true)
+
+  const fetchData = useCallback(async () => {
+    try {
+      const res = await fetch(url)
+      if (!res.ok) throw new Error(`HTTP ${res.status}: ${res.statusText}`)
+      const json: T = await res.json()
+      setData(json)
+      setError(null)
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Request failed'
+      setError(msg)
+      push(msg, 'error')
+    } finally {
+      if (isFirstFetch.current) {
+        isFirstFetch.current = false
+        setLoading(false)
+      }
+    }
+  }, [url, push])
+
+  const refetch = useCallback(() => {
+    void fetchData()
+  }, [fetchData])
+
+  useEffect(() => {
+    isFirstFetch.current = true
+    setLoading(true)
+    void fetchData()
+    if (!intervalMs) return
+    const id = setInterval(() => { void fetchData() }, intervalMs)
+    return () => clearInterval(id)
+  }, [fetchData, intervalMs])
+
+  return { data, loading, error, refetch }
+}
+```
+
+---
+
+### Task 7: Apply Skeleton + EmptyState to components
+
+**Files:**
+- Modify: `src/components/pipeline/KanbanBoard.tsx`
+- Modify: `src/components/agents/AgentGrid.tsx`
+- Modify: `src/components/logs/LogViewer.tsx`
+- Modify: `src/components/logs/DecisionTrail.tsx`
+
+**KanbanBoard.tsx** - KanbanColumn: add `loading?: boolean` prop to board props and column. When loading, show 3 skeleton cards. Empty column → EmptyState.
+
+Add `loading?: boolean` to `KanbanBoardProps` and pass down. In `KanbanColumn`, when `tasks.length === 0 && !loading` show EmptyState.
+
+In `KanbanBoard` when `loading`, show skeleton columns instead (or pass loading to KanbanColumn).
+
+**AgentGrid.tsx** - Add `loading` state (set true initially). When loading show 6 skeleton cards. When no agents → EmptyState.
+
+**LogViewer.tsx** - Replace "Loading logs…" text with 8 Skeleton lines. When filteredLines.length === 0 and not loading → EmptyState.
+
+**DecisionTrail.tsx** - When loading, already shows spinner text → replace with Skeleton. When filtered.length === 0 and !loading → EmptyState (replace existing "No decisions found" in table).
+
+---
+
+### Task 8: src/main.tsx — wrap routes
+
+**Files:**
+- Modify: `src/main.tsx`
+
+Add ErrorBoundary around each route element, wrap everything in ToastProvider, add ToastStack:
+
+```tsx
+import { ToastProvider } from './hooks/useToast'
+import ErrorBoundary from './components/layout/ErrorBoundary'
+import ToastStack from './components/layout/Toast'
+
+// Wrap routes:
+<ToastProvider>
+  <BrowserRouter>
+    <Routes>
+      <Route element={<App />}>
+        <Route index element={<ErrorBoundary><PipelinePage /></ErrorBoundary>} />
+        <Route path="agents" element={<ErrorBoundary><AgentsPage /></ErrorBoundary>} />
+        <Route path="system" element={<ErrorBoundary><SystemPage /></ErrorBoundary>} />
+        <Route path="logs" element={<ErrorBoundary><LogsPage /></ErrorBoundary>} />
+        <Route path="config" element={<ErrorBoundary><ConfigPage /></ErrorBoundary>} />
+      </Route>
+    </Routes>
+    <ToastStack />
+  </BrowserRouter>
+</ToastProvider>
+```
+
+---
+
+### Task 9: tests/client/ux-polish.test.tsx (new)
+
+**Files:**
+- Create: `tests/client/ux-polish.test.tsx`
+
+Tests:
+1. Toast: push 6 → max 5 visible
+2. Toast: error variant has no auto-timer (stays)
+3. Toast: success auto-dismisses (mock timers)
+4. Skeleton: renders with animate-skeleton class
+5. EmptyState: renders icon + title + action button
+6. ErrorBoundary: catches error, shows retry button
+7. useApi: loading=true on first fetch, loading=false after
+
+---
+
+### Task 10: Verify and commit
+
+```bash
+npx vitest run
+npm run typecheck
+npm run build
+git add -A
+git commit -m "feat(#10): UX Polish — Toast + ErrorBoundary + Skeleton + EmptyState"
+git push origin feat/issue-10
+openclaw system event --text "Done: issue-10 UX Polish — feat/issue-10 pushed, tests pass, build clean" --mode now
+```

--- a/src/components/agents/AgentGrid.tsx
+++ b/src/components/agents/AgentGrid.tsx
@@ -2,6 +2,8 @@ import { useState, useEffect, useCallback } from 'react'
 import type { AgentInfo } from '../../lib/api'
 import { fetchAgents } from '../../lib/api'
 import AgentCard from './AgentCard'
+import Skeleton from '../ui/Skeleton'
+import EmptyState from '../ui/EmptyState'
 
 interface AgentGridProps {
   onSelectAgent: (agent: AgentInfo) => void
@@ -10,6 +12,7 @@ interface AgentGridProps {
 export default function AgentGrid({ onSelectAgent }: AgentGridProps) {
   const [agents, setAgents] = useState<AgentInfo[]>([])
   const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
 
   const load = useCallback(async () => {
     try {
@@ -18,6 +21,8 @@ export default function AgentGrid({ onSelectAgent }: AgentGridProps) {
       setError(null)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load agents')
+    } finally {
+      setLoading(false)
     }
   }, [])
 
@@ -35,6 +40,22 @@ export default function AgentGrid({ onSelectAgent }: AgentGridProps) {
           Retry
         </button>
       </div>
+    )
+  }
+
+  if (loading) {
+    return (
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <Skeleton key={i} className="h-24 rounded-lg" />
+        ))}
+      </div>
+    )
+  }
+
+  if (agents.length === 0) {
+    return (
+      <EmptyState icon="◎" title="No agents found" description="No active agent sessions" />
     )
   }
 

--- a/src/components/layout/ErrorBoundary.tsx
+++ b/src/components/layout/ErrorBoundary.tsx
@@ -1,0 +1,60 @@
+import { Component } from 'react'
+import type { ReactNode } from 'react'
+
+interface ErrorBoundaryProps {
+  children: ReactNode
+  fallback?: ReactNode
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean
+  message: string
+}
+
+export default class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props)
+    this.state = { hasError: false, message: '' }
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, message: error.message }
+  }
+
+  override render() {
+    if (this.state.hasError) {
+      if (this.props.fallback) return this.props.fallback
+      return (
+        <div className="m-4 p-4 rounded-lg bg-red-subtle border border-red-dim text-text-primary">
+          <p className="text-sm font-medium mb-2">Something went wrong</p>
+          <p className="text-xs text-text-secondary mb-4 font-mono">{this.state.message}</p>
+          <button
+            onClick={() => window.location.reload()}
+            className="px-3 py-1.5 text-xs rounded-sm border border-border-default text-text-secondary hover:bg-bg-hover transition-colors"
+          >
+            Retry
+          </button>
+        </div>
+      )
+    }
+    return this.props.children
+  }
+}
+
+interface InlineErrorCardProps {
+  message: string
+  onRetry?: () => void
+}
+
+export function InlineErrorCard({ message, onRetry }: InlineErrorCardProps) {
+  return (
+    <div className="p-3 rounded-md bg-red-subtle border border-red-dim text-text-primary text-sm">
+      <span className="text-xs font-mono">{message}</span>
+      {onRetry && (
+        <button onClick={onRetry} className="ml-3 text-xs text-accent-amber hover:underline">
+          Retry
+        </button>
+      )}
+    </div>
+  )
+}

--- a/src/components/layout/Toast.tsx
+++ b/src/components/layout/Toast.tsx
@@ -1,0 +1,43 @@
+import { useToast } from '../../hooks/useToast'
+import type { Toast, ToastVariant } from '../../hooks/useToast'
+
+const VARIANT_STYLES: Record<ToastVariant, { border: string; icon: string }> = {
+  success: { border: 'border-l-4 border-emerald', icon: '✓' },
+  warning: { border: 'border-l-4 border-amber',   icon: '⚠' },
+  error:   { border: 'border-l-4 border-red',     icon: '✕' },
+  info:    { border: 'border-l-4 border-blue',    icon: 'ℹ' },
+}
+
+function ToastItem({ toast }: { toast: Toast }) {
+  const { dismiss } = useToast()
+  const { border, icon } = VARIANT_STYLES[toast.variant]
+  return (
+    <div
+      role="alert"
+      className={`flex items-start gap-3 px-4 py-3 rounded-md shadow-lg text-text-primary text-sm bg-bg-elevated animate-slide-in-right ${border}`}
+    >
+      <span className="shrink-0 font-mono">{icon}</span>
+      <span className="flex-1">{toast.message}</span>
+      {toast.action && (
+        <button onClick={toast.action.fn} className="text-xs text-accent-amber hover:underline shrink-0">
+          {toast.action.label}
+        </button>
+      )}
+      {toast.dismissible !== false && (
+        <button onClick={() => dismiss(toast.id)} aria-label="Dismiss" className="shrink-0 text-text-tertiary hover:text-text-primary">
+          ×
+        </button>
+      )}
+    </div>
+  )
+}
+
+export default function ToastStack() {
+  const { toasts } = useToast()
+  if (toasts.length === 0) return null
+  return (
+    <div className="fixed bottom-4 right-4 z-50 flex flex-col gap-2 max-w-sm w-full">
+      {toasts.map((t) => <ToastItem key={t.id} toast={t} />)}
+    </div>
+  )
+}

--- a/src/components/logs/DecisionTrail.tsx
+++ b/src/components/logs/DecisionTrail.tsx
@@ -1,5 +1,7 @@
 import { useState, useEffect, useMemo } from 'react'
 import { getDecisions, type Decision } from '../../lib/api'
+import Skeleton from '../ui/Skeleton'
+import EmptyState from '../ui/EmptyState'
 
 type SortField = 'agent' | 'task_id' | 'gate_type' | 'result' | 'timestamp'
 type SortDir = 'asc' | 'desc'
@@ -81,7 +83,11 @@ export default function DecisionTrail() {
   }
 
   if (loading) {
-    return <div className="flex items-center justify-center h-full text-text-tertiary text-sm">Loading decisions…</div>
+    return (
+      <div className="flex-1 p-3 space-y-2">
+        <Skeleton lines={5} height="24px" className="w-full" />
+      </div>
+    )
   }
   if (error) {
     return <div className="flex items-center justify-center h-full text-accent-red text-sm">{error}</div>
@@ -143,8 +149,10 @@ export default function DecisionTrail() {
           <tbody>
             {filtered.length === 0 ? (
               <tr>
-                <td colSpan={5} className="px-3 py-8 text-center text-text-tertiary">
-                  No decisions found
+                <td colSpan={5}>
+                  <div className="flex items-center justify-center py-8">
+                    <EmptyState icon="◇" title="No decisions recorded" />
+                  </div>
                 </td>
               </tr>
             ) : (

--- a/src/components/logs/LogViewer.tsx
+++ b/src/components/logs/LogViewer.tsx
@@ -1,5 +1,7 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react'
 import { useVirtualizer } from '@tanstack/react-virtual'
+import Skeleton from '../ui/Skeleton'
+import EmptyState from '../ui/EmptyState'
 
 interface LogViewerProps {
   lines: string[]
@@ -135,8 +137,8 @@ export default function LogViewer({ lines, loading, error, paused }: LogViewerPr
           {error}
         </div>
       ) : loading && lines.length === 0 ? (
-        <div className="flex-1 flex items-center justify-center text-text-tertiary text-sm">
-          Loading logs…
+        <div className="p-3 space-y-2">
+          <Skeleton lines={8} height="16px" className="w-full" />
         </div>
       ) : (
         <div
@@ -144,6 +146,11 @@ export default function LogViewer({ lines, loading, error, paused }: LogViewerPr
           onScroll={handleScroll}
           className="flex-1 overflow-auto font-mono text-xs"
         >
+          {filteredLines.length === 0 && !loading && !error ? (
+            <div className="flex-1 flex items-center justify-center">
+              <EmptyState icon="≡" title="No log entries" description="Nothing to show yet" />
+            </div>
+          ) : null}
           <div
             style={{
               height: `${virtualizer.getTotalSize()}px`,

--- a/src/components/pipeline/KanbanBoard.tsx
+++ b/src/components/pipeline/KanbanBoard.tsx
@@ -19,6 +19,8 @@ import type { Task, PipelineState, TransitionError } from '../../lib/types';
 import { MAIN_FLOW_STATES, SIDE_STATES } from '../../lib/types';
 import { transitionTask } from '../../lib/api';
 import { TaskCard } from './TaskCard';
+import Skeleton from '../ui/Skeleton';
+import EmptyState from '../ui/EmptyState';
 
 // Pipeline state color map for column headers
 const STATE_COLORS: Record<PipelineState, string> = {
@@ -47,9 +49,10 @@ interface KanbanColumnProps {
   tasks: Task[];
   onCardClick: (task: Task) => void;
   errors: Record<string, TransitionError>;
+  loading?: boolean;
 }
 
-function KanbanColumn({ state, tasks, onCardClick, errors }: KanbanColumnProps) {
+function KanbanColumn({ state, tasks, onCardClick, errors, loading }: KanbanColumnProps) {
   const { setNodeRef, isOver } = useDroppable({ id: state });
   const color = STATE_COLORS[state];
 
@@ -80,18 +83,30 @@ function KanbanColumn({ state, tasks, onCardClick, errors }: KanbanColumnProps) 
       </div>
 
       {/* Cards */}
-      <SortableContext items={tasks.map((t) => t.id)} strategy={verticalListSortingStrategy}>
-        <div className="flex-1 p-2 space-y-2 overflow-y-auto min-h-[100px]">
-          {tasks.map((task) => (
-            <TaskCard
-              key={task.id}
-              task={task}
-              onClick={onCardClick}
-              error={errors[task.id] || null}
-            />
-          ))}
+      {loading ? (
+        <div className="flex-1 p-2 space-y-2">
+          <Skeleton className="h-16 rounded-md" />
+          <Skeleton className="h-16 rounded-md" />
+          <Skeleton className="h-16 rounded-md" />
         </div>
-      </SortableContext>
+      ) : tasks.length === 0 ? (
+        <div className="flex-1 p-2">
+          <EmptyState icon="○" title={`No tasks in ${state}`} />
+        </div>
+      ) : (
+        <SortableContext items={tasks.map((t) => t.id)} strategy={verticalListSortingStrategy}>
+          <div className="flex-1 p-2 space-y-2 overflow-y-auto min-h-[100px]">
+            {tasks.map((task) => (
+              <TaskCard
+                key={task.id}
+                task={task}
+                onClick={onCardClick}
+                error={errors[task.id] || null}
+              />
+            ))}
+          </div>
+        </SortableContext>
+      )}
     </div>
   );
 }
@@ -100,9 +115,10 @@ interface KanbanBoardProps {
   tasks: Task[];
   onCardClick: (task: Task) => void;
   onRefresh: () => void;
+  loading?: boolean;
 }
 
-export function KanbanBoard({ tasks, onCardClick, onRefresh }: KanbanBoardProps) {
+export function KanbanBoard({ tasks, onCardClick, onRefresh, loading }: KanbanBoardProps) {
   const [activeTask, setActiveTask] = useState<Task | null>(null);
   const [toast, setToast] = useState<string | null>(null);
   const [errors, setErrors] = useState<Record<string, TransitionError>>({});
@@ -192,6 +208,7 @@ export function KanbanBoard({ tasks, onCardClick, onRefresh }: KanbanBoardProps)
               tasks={tasksByState(state)}
               onCardClick={onCardClick}
               errors={errors}
+              loading={loading}
             />
           ))}
         </div>

--- a/src/components/system/ServicesGrid.tsx
+++ b/src/components/system/ServicesGrid.tsx
@@ -1,4 +1,6 @@
 import type { ServiceInfo } from '../../lib/types'
+import Skeleton from '../ui/Skeleton'
+import EmptyState from '../ui/EmptyState'
 
 const GROUPS = ['Core', 'Agents', 'Integrations'] as const
 const STATUS_STYLES: Record<string, string> = {
@@ -28,7 +30,7 @@ export default function ServicesGrid({ services, loading, onAction }: ServicesGr
             <div className="mb-3 h-4 w-24 rounded bg-bg-overlay" />
             <div className="space-y-3">
               {Array.from({ length: 2 }).map((_, index) => (
-                <div key={index} className="h-28 animate-skeleton rounded-md bg-gradient-to-r from-bg-overlay via-bg-hover to-bg-overlay" />
+                <Skeleton key={index} className="h-28" />
               ))}
             </div>
           </div>
@@ -50,6 +52,9 @@ export default function ServicesGrid({ services, loading, onAction }: ServicesGr
               </span>
             </div>
             <div className="space-y-3">
+              {items.length === 0 && (
+                <EmptyState icon="○" title={`No ${group} services`} />
+              )}
               {items.map((service) => (
                 <article
                   key={service.name}

--- a/src/components/ui/EmptyState.tsx
+++ b/src/components/ui/EmptyState.tsx
@@ -1,0 +1,24 @@
+interface EmptyStateProps {
+  icon: string
+  title: string
+  description?: string
+  action?: { label: string; onClick: () => void }
+}
+
+export default function EmptyState({ icon, title, description, action }: EmptyStateProps) {
+  return (
+    <div className="flex flex-col items-center justify-center p-8 bg-bg-surface border border-border-subtle rounded-lg text-center">
+      <span className="text-2xl mb-3 text-text-tertiary">{icon}</span>
+      <p className="text-sm font-medium text-text-secondary">{title}</p>
+      {description && <p className="text-xs text-text-tertiary mt-1">{description}</p>}
+      {action && (
+        <button
+          onClick={action.onClick}
+          className="mt-4 px-3 py-1.5 text-xs rounded-sm border border-border-default text-text-secondary hover:bg-bg-hover hover:text-text-primary transition-colors"
+        >
+          {action.label}
+        </button>
+      )}
+    </div>
+  )
+}

--- a/src/components/ui/Skeleton.tsx
+++ b/src/components/ui/Skeleton.tsx
@@ -1,0 +1,28 @@
+import type { CSSProperties } from 'react'
+
+interface SkeletonProps {
+  className?: string
+  width?: string
+  height?: string
+  lines?: number
+}
+
+export default function Skeleton({ className = '', width, height, lines }: SkeletonProps) {
+  const style: CSSProperties = {}
+  if (width) style.width = width
+  if (height) style.height = height
+
+  const baseClass = `animate-skeleton rounded bg-gradient-to-r from-bg-surface via-bg-elevated to-bg-surface bg-[length:200%_100%] ${className}`
+
+  if (lines && lines > 1) {
+    return (
+      <div className="space-y-2">
+        {Array.from({ length: lines }).map((_, i) => (
+          <div key={i} style={style} className={baseClass} />
+        ))}
+      </div>
+    )
+  }
+
+  return <div style={style} className={baseClass} />
+}

--- a/src/hooks/useApi.ts
+++ b/src/hooks/useApi.ts
@@ -1,0 +1,51 @@
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { useToast } from './useToast'
+
+interface UseApiResult<T> {
+  data: T | null
+  loading: boolean
+  error: string | null
+  refetch: () => void
+}
+
+export function useApi<T>(url: string, intervalMs?: number): UseApiResult<T> {
+  const [data, setData] = useState<T | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const { push } = useToast()
+  const isFirstFetch = useRef(true)
+
+  const fetchData = useCallback(async () => {
+    try {
+      const res = await fetch(url)
+      if (!res.ok) throw new Error(`HTTP ${res.status}: ${res.statusText}`)
+      const json = (await res.json()) as T
+      setData(json)
+      setError(null)
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Request failed'
+      setError(msg)
+      push(msg, 'error')
+    } finally {
+      if (isFirstFetch.current) {
+        isFirstFetch.current = false
+        setLoading(false)
+      }
+    }
+  }, [url, push])
+
+  const refetch = useCallback(() => {
+    void fetchData()
+  }, [fetchData])
+
+  useEffect(() => {
+    isFirstFetch.current = true
+    setLoading(true)
+    void fetchData()
+    if (!intervalMs) return
+    const id = setInterval(() => { void fetchData() }, intervalMs)
+    return () => clearInterval(id)
+  }, [fetchData, intervalMs])
+
+  return { data, loading, error, refetch }
+}

--- a/src/hooks/useToast.tsx
+++ b/src/hooks/useToast.tsx
@@ -1,0 +1,81 @@
+import { createContext, useContext, useState, useRef, useCallback } from 'react'
+import type { ReactNode } from 'react'
+
+export type ToastVariant = 'success' | 'warning' | 'error' | 'info'
+
+export interface Toast {
+  id: string
+  message: string
+  variant: ToastVariant
+  dismissible?: boolean
+  action?: { label: string; fn: () => void }
+}
+
+interface ToastContextValue {
+  toasts: Toast[]
+  push: (message: string, variant: ToastVariant, options?: Partial<Omit<Toast, 'id' | 'message' | 'variant'>>) => void
+  dismiss: (id: string) => void
+  dismissAll: () => void
+}
+
+const ToastContext = createContext<ToastContextValue | null>(null)
+
+const AUTO_DISMISS_MS: Record<ToastVariant, number | null> = {
+  success: 5000,
+  info: 5000,
+  warning: 8000,
+  error: null,
+}
+const MAX_TOASTS = 5
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<Toast[]>([])
+  const timers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map())
+
+  const dismiss = useCallback((id: string) => {
+    const t = timers.current.get(id)
+    if (t) { clearTimeout(t); timers.current.delete(id) }
+    setToasts((prev) => prev.filter((toast) => toast.id !== id))
+  }, [])
+
+  const push = useCallback((
+    message: string,
+    variant: ToastVariant,
+    options?: Partial<Omit<Toast, 'id' | 'message' | 'variant'>>
+  ) => {
+    const id = `${Date.now()}-${Math.random()}`
+    const toast: Toast = { id, message, variant, dismissible: true, ...options }
+    setToasts((prev) => {
+      const next = [...prev, toast]
+      if (next.length > MAX_TOASTS) {
+        const removed = next.shift()!
+        const oldTimer = timers.current.get(removed.id)
+        if (oldTimer) { clearTimeout(oldTimer); timers.current.delete(removed.id) }
+      }
+      return next
+    })
+    const delay = AUTO_DISMISS_MS[variant]
+    if (delay !== null) {
+      const t = setTimeout(() => dismiss(id), delay)
+      timers.current.set(id, t)
+    }
+  }, [dismiss])
+
+  const dismissAll = useCallback(() => {
+    timers.current.forEach((t) => clearTimeout(t))
+    timers.current.clear()
+    setToasts([])
+  }, [])
+
+  return (
+    <ToastContext.Provider value={{ toasts, push, dismiss, dismissAll }}>
+      {children}
+    </ToastContext.Provider>
+  )
+}
+
+export function useToast(): ToastContextValue {
+  const ctx = useContext(ToastContext)
+  if (!ctx) throw new Error('useToast must be used within ToastProvider')
+  return ctx
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,20 +7,26 @@ import AgentsPage from './pages/AgentsPage'
 import SystemPage from './pages/SystemPage'
 import LogsPage from './pages/LogsPage'
 import ConfigPage from './pages/ConfigPage'
+import { ToastProvider } from './hooks/useToast'
+import ErrorBoundary from './components/layout/ErrorBoundary'
+import ToastStack from './components/layout/Toast'
 import './index.css'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <BrowserRouter>
-      <Routes>
-        <Route element={<App />}>
-          <Route index element={<PipelinePage />} />
-          <Route path="agents" element={<AgentsPage />} />
-          <Route path="system" element={<SystemPage />} />
-          <Route path="logs" element={<LogsPage />} />
-          <Route path="config" element={<ConfigPage />} />
-        </Route>
-      </Routes>
-    </BrowserRouter>
+    <ToastProvider>
+      <BrowserRouter>
+        <Routes>
+          <Route element={<App />}>
+            <Route index element={<ErrorBoundary><PipelinePage /></ErrorBoundary>} />
+            <Route path="agents" element={<ErrorBoundary><AgentsPage /></ErrorBoundary>} />
+            <Route path="system" element={<ErrorBoundary><SystemPage /></ErrorBoundary>} />
+            <Route path="logs" element={<ErrorBoundary><LogsPage /></ErrorBoundary>} />
+            <Route path="config" element={<ErrorBoundary><ConfigPage /></ErrorBoundary>} />
+          </Route>
+        </Routes>
+        <ToastStack />
+      </BrowserRouter>
+    </ToastProvider>
   </React.StrictMode>,
 )

--- a/tests/client/ux-polish.test.tsx
+++ b/tests/client/ux-polish.test.tsx
@@ -1,0 +1,139 @@
+import { render, screen, fireEvent, act, cleanup } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { ToastProvider, useToast } from '../../src/hooks/useToast'
+import ToastStack from '../../src/components/layout/Toast'
+import Skeleton from '../../src/components/ui/Skeleton'
+import EmptyState from '../../src/components/ui/EmptyState'
+import ErrorBoundary from '../../src/components/layout/ErrorBoundary'
+import { useApi } from '../../src/hooks/useApi'
+
+// Helper: render toast system
+function ToastHarness({ action }: { action: (ctx: ReturnType<typeof useToast>) => void }) {
+  const toast = useToast()
+  return (
+    <button onClick={() => action(toast)}>trigger</button>
+  )
+}
+
+function renderWithToast(action: (ctx: ReturnType<typeof useToast>) => void) {
+  return render(
+    <ToastProvider>
+      <ToastHarness action={action} />
+      <ToastStack />
+    </ToastProvider>
+  )
+}
+
+describe('Toast', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => {
+    act(() => { vi.runAllTimers() })
+    cleanup()
+    vi.useRealTimers()
+  })
+
+  it('caps at 5 toasts when 6 are pushed', () => {
+    renderWithToast((toast) => {
+      for (let i = 0; i < 6; i++) {
+        toast.push(`Message ${i}`, 'info')
+      }
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'trigger' }))
+    const alerts = screen.getAllByRole('alert')
+    expect(alerts).toHaveLength(5)
+  })
+
+  it('error toast does not auto-dismiss', () => {
+    renderWithToast((toast) => toast.push('Error!', 'error'))
+    fireEvent.click(screen.getByRole('button', { name: 'trigger' }))
+    expect(screen.getAllByRole('alert')).toHaveLength(1)
+    act(() => { vi.advanceTimersByTime(10000) })
+    expect(screen.getAllByRole('alert')).toHaveLength(1)
+  })
+
+  it('success toast auto-dismisses after 5000ms', () => {
+    renderWithToast((toast) => toast.push('Done!', 'success'))
+    fireEvent.click(screen.getByRole('button', { name: 'trigger' }))
+    expect(screen.getAllByRole('alert')).toHaveLength(1)
+    act(() => { vi.advanceTimersByTime(5001) })
+    expect(screen.queryAllByRole('alert')).toHaveLength(0)
+  })
+})
+
+describe('Skeleton', () => {
+  it('renders with animate-skeleton class', () => {
+    const { container } = render(<Skeleton className="h-4" />)
+    const el = container.firstChild as HTMLElement
+    expect(el.className).toContain('animate-skeleton')
+  })
+
+  it('renders multiple lines when lines prop provided', () => {
+    const { container } = render(<Skeleton lines={3} height="16px" />)
+    // The wrapper div contains 3 skeleton divs
+    const wrapper = container.firstChild as HTMLElement
+    expect(wrapper.children).toHaveLength(3)
+  })
+})
+
+describe('EmptyState', () => {
+  it('renders icon and title', () => {
+    render(<EmptyState icon="○" title="No items" />)
+    expect(screen.getByText('○')).toBeTruthy()
+    expect(screen.getByText('No items')).toBeTruthy()
+  })
+
+  it('renders action button and calls onClick', () => {
+    const onClick = vi.fn()
+    render(<EmptyState icon="○" title="No items" action={{ label: 'Add one', onClick }} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Add one' }))
+    expect(onClick).toHaveBeenCalledOnce()
+  })
+})
+
+describe('ErrorBoundary', () => {
+  it('catches render error and shows retry button', () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    function Bomb() {
+      throw new Error('test crash')
+    }
+    render(
+      <ErrorBoundary>
+        <Bomb />
+      </ErrorBoundary>
+    )
+    expect(screen.getByText('Something went wrong')).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeTruthy()
+    consoleSpy.mockRestore()
+  })
+})
+
+describe('useApi', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('loading=true on first fetch, false after data', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ items: [] }),
+    }))
+
+    let capturedResult: { loading: boolean; data: unknown } | null = null
+
+    function ApiConsumer() {
+      const result = useApi<{ items: unknown[] }>('/api/test')
+      capturedResult = { loading: result.loading, data: result.data }
+      return <div data-testid="status">{result.loading ? 'loading' : 'done'}</div>
+    }
+
+    const { findByText } = render(
+      <ToastProvider>
+        <ApiConsumer />
+      </ToastProvider>
+    )
+    // Initially loading
+    expect(screen.getByTestId('status').textContent).toBe('loading')
+    // After fetch resolves
+    await findByText('done')
+    expect(capturedResult?.loading).toBe(false)
+    expect(capturedResult?.data).toEqual({ items: [] })
+  })
+})


### PR DESCRIPTION
## Summary

Implements issue #10 — final UX hardening pass for ao-dashboard.

## Changes
- `src/components/layout/Toast.tsx` — 4 variants (success/warning/error/info), slide-in-right animation, max 5 stack, auto-dismiss (success/info=5s, warning=8s, error=never)
- `src/hooks/useToast.ts` — ToastContext + ToastProvider + useToast hook, variant support
- `src/components/layout/ErrorBoundary.tsx` — React class component, error card with Retry button
- `src/components/ui/Skeleton.tsx` — reusable shimmer block, animate-skeleton (1.8s linear infinite)
- `src/components/ui/EmptyState.tsx` — icon + title + description + optional action
- `src/hooks/useApi.ts` — loading only on first fetch, error state, refetch
- Applied skeleton + empty states to: KanbanBoard, AgentGrid, ServicesGrid, LogViewer
- `src/App.tsx` — each route wrapped in ErrorBoundary + ToastProvider

## Task
- task_id: `tsk_20260320_e717ef`
- Issue: closes #10

Reviewed by archimedes via code-review-gate before merge.