### PR TITLE
fix(#11,#8,#10): rate-limits/status fixes + logs TASKS_DIR + UX polish verification

### DIFF
--- a/server/api/logs.js
+++ b/server/api/logs.js
@@ -6,7 +6,7 @@ import { homedir } from 'os'
 const router = Router()
 
 const OPENCLAW_DIR = '/tmp/openclaw'
-const TASKS_DIR = join(homedir(), 'clawd/tasks/active')
+const TASKS_DIR = join(homedir(), 'clawd/tasks')
 
 /**
  * Compute today's date string in Lisbon timezone (YYYY-MM-DD).
@@ -149,10 +149,17 @@ router.get('/worker/:name', async (req, res) => {
   }
 })
 
+// Skip non-task dirs when iterating clawd/tasks
+const NON_TASK_DIRS = new Set(['active', 'archive', 'config', 'metrics', 'templates'])
+
+function isTaskDir(name) {
+  return name.startsWith('tsk_') && !NON_TASK_DIRS.has(name)
+}
+
 // GET /api/decisions — aggregate decision-log.jsonl across all task dirs
 router.get('/decisions', async (req, res) => {
   try {
-    const taskDirs = await listDirs(TASKS_DIR)
+    const taskDirs = (await listDirs(TASKS_DIR)).filter(isTaskDir)
     const allDecisions = []
 
     for (const dir of taskDirs) {
@@ -188,7 +195,7 @@ router.get('/decisions', async (req, res) => {
 // GET /api/events — aggregate events.ndjson across all task dirs
 router.get('/events', async (req, res) => {
   try {
-    const taskDirs = await listDirs(TASKS_DIR)
+    const taskDirs = (await listDirs(TASKS_DIR)).filter(isTaskDir)
     const allEvents = []
 
     for (const dir of taskDirs) {
@@ -208,7 +215,8 @@ router.get('/events', async (req, res) => {
       filtered = filtered.filter((e) => e.task_id === req.query.task_id)
     }
     if (req.query.type) {
-      filtered = filtered.filter((e) => e.type === req.query.type)
+      // match both 'type' and 'event_type' fields
+      filtered = filtered.filter((e) => e.type === req.query.type || e.event_type === req.query.type)
     }
 
     // Sort by timestamp descending

--- a/server/api/status.js
+++ b/server/api/status.js
@@ -80,17 +80,26 @@ async function assembleStatus() {
     // not available or no failures
   }
 
-  // Claude/Codex usage — read from status files if available
+  // Claude/Codex usage — read from rate-limit-cache.json (written by gateway on each API call)
   let claudeUsagePercent = null
   let codexUsagePercent = null
   try {
-    const ratesPath = join(homedir(), 'clawd/memory/rate-limits.json')
-    const ratesRaw = await readFile(ratesPath, 'utf-8')
-    const rates = JSON.parse(ratesRaw)
-    claudeUsagePercent = rates.claude_usage_percent ?? null
-    codexUsagePercent = rates.codex_usage_percent ?? null
+    const cachePath = join(homedir(), 'clawd/runtime/rate-limit-cache.json')
+    const cacheRaw = await readFile(cachePath, 'utf-8')
+    const cache = JSON.parse(cacheRaw)
+    const profiles = Array.isArray(cache.profiles) ? cache.profiles : []
+    // Yura profile = primary Claude usage
+    const yura = profiles.find((p) => p.profile === 'yura')
+    if (yura && yura.tokens_limit > 0) {
+      claudeUsagePercent = Math.round((yura.tokens_used / yura.tokens_limit) * 100)
+    }
+    // Codex profile
+    const codex = profiles.find((p) => p.profile === 'codex')
+    if (codex && codex.tokens_limit > 0) {
+      codexUsagePercent = Math.round((codex.tokens_used / codex.tokens_limit) * 100)
+    }
   } catch {
-    // not available
+    // cache not available — return null (UI shows '—')
   }
 
   const result = {


### PR DESCRIPTION
## Summary

Closes #11, #8, #10.

## #11 — rate-limits cache + /api/status aggregator

### server/api/status.js — claude_usage_percent fix
- Was reading from `clawd/memory/rate-limits.json` (non-existent → always null)
- Now reads from `~/clawd/runtime/rate-limit-cache.json` (same file rate-limits.js uses)
- Extracts `yura` profile → `claude_usage_percent = round(tokens_used/tokens_limit * 100)`
- Extracts `codex` profile → `codex_usage_percent`
- TopBar now shows real usage bars

### server/api/rate-limits.js (no changes needed)
- `GET /api/rate-limits`: already reads cache file, handles stale/missing ✅
- `POST /api/rate-limits/switch`: already handles both `{to:}` and `{profile:}` ✅

### Verification
```
/api/status: 33ms, 12 fields ✅
claude_usage_percent: 42 (was null) ✅
/api/rate-limits: profiles=[yura, dima, codex], cached=false, stale=true ✅
POST /api/rate-limits/switch: ok=true, writes active-profile.json ✅
```

## #8 — Logs page

### server/api/logs.js — TASKS_DIR fix
- Was: `~/clawd/tasks/active` (empty dir → 0 events, 0 decisions)
- Now: `~/clawd/tasks` with `isTaskDir()` filter (skip active/archive/config/metrics/templates)
- `GET /api/events`: 121 events now returned ✅
- `GET /api/decisions`: 1 decision now returned ✅
- Event type filter: now matches both `type` and `event_type` fields

### Frontend components (already implemented in prior PRs)
- `LogViewer.tsx`: virtual scroll, color-coded levels, filter bar, pause/resume, JSON expand ✅
- `DecisionTrail.tsx`: sortable table, agent/task_id/date filters ✅
- `EventStream.tsx`: filterable feed with type icons ✅
- `LogsPage.tsx`: 4-tab layout (Gateway/Workers/Decisions/Events) ✅

## #10 — UX Polish (verification — all implemented in PR#30/#31/#32)

- `Skeleton.tsx`: `animate-skeleton` shimmer from design tokens ✅
- `EmptyState.tsx`: icon + title ✅
- `ErrorBoundary.tsx`: React class boundary with Retry button ✅
- `Toast.tsx` + `useToast.tsx`: 4 variants, auto-dismiss (success 5s, error never), MAX_TOASTS=5 ✅
- KanbanBoard: EmptyState per column ("No tasks in {state}") ✅
- AgentGrid: Skeleton cards on loading ✅
- ServicesGrid: Skeleton tiles on loading ✅

## Build

Clean: tsc + vite, 2.22s, 520KB ✅