### PR TITLE
fix(#38,#39,#46): Phase 2 Design System — pills, pulses, sidebar, stats

### DIFF
--- a/src/components/agents/AgentCard.tsx
+++ b/src/components/agents/AgentCard.tsx
@@ -15,7 +15,7 @@ function relativeTime(isoString: string | null): string {
 
 const STATUS_STYLES: Record<string, { dot: string; ring: string; animation?: string }> = {
   active:  { dot: 'bg-status-active', ring: 'ring-status-active/30', animation: 'animate-pulse-active' },
-  idle:    { dot: 'bg-status-idle',   ring: 'ring-status-idle/20' },
+  idle:    { dot: 'bg-status-healthy', ring: 'ring-status-healthy/20', animation: 'animate-pulse-healthy' },
   dead:    { dot: 'bg-status-critical', ring: 'ring-status-critical/30', animation: 'animate-pulse-critical' },
   waiting: { dot: 'bg-accent-purple', ring: 'ring-accent-purple/30' },
   unknown: { dot: 'bg-text-disabled', ring: 'ring-text-disabled/20' },
@@ -70,10 +70,10 @@ export default function AgentCard({ agent, onClick }: AgentCardProps) {
           </div>
 
           <div className="flex gap-1.5 mt-2">
-            <MailBadge label="in" count={agent.mailbox.inbox} color="bg-accent-blue/20 text-accent-blue" />
-            <MailBadge label="proc" count={agent.mailbox.processing} color="bg-accent-amber-subtle text-accent-amber" />
-            <MailBadge label="done" count={agent.mailbox.done} color="bg-accent-emerald-subtle text-accent-emerald" />
-            <MailBadge label="dead" count={agent.mailbox.deadletter} color="bg-accent-red-subtle text-accent-red" />
+            <MailBadge label="in" count={agent.mailbox.inbox} color="bg-accent-blue/20 text-text-tertiary" highlightColor="bg-amber-subtle text-amber font-semibold" />
+            <MailBadge label="proc" count={agent.mailbox.processing} color="bg-accent-amber-subtle text-text-tertiary" />
+            <MailBadge label="done" count={agent.mailbox.done} color="bg-accent-emerald-subtle text-text-tertiary" />
+            <MailBadge label="dead" count={agent.mailbox.deadletter} color="bg-accent-red-subtle text-text-tertiary" highlightColor="bg-red-subtle text-red font-semibold" />
           </div>
         </div>
       </div>
@@ -81,9 +81,11 @@ export default function AgentCard({ agent, onClick }: AgentCardProps) {
   )
 }
 
-function MailBadge({ label, count, color }: { label: string; count: number; color: string }) {
+function MailBadge({ label, count, color, highlightColor }: { label: string; count: number; color: string; highlightColor?: string }) {
+  // Highlight non-zero inbox (amber) and deadletter (red)
+  const active = count > 0 && highlightColor
   return (
-    <span className={`inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded text-[10px] font-mono ${color}`}>
+    <span className={`inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded text-[10px] font-mono ${active ? highlightColor : color}`}>
       {label}:{count}
     </span>
   )

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -108,10 +108,10 @@ export default function Sidebar({ status, onClose }: SidebarProps) {
             end={item.to === '/'}
             onClick={onClose}
             className={({ isActive }) =>
-              `flex items-center gap-3 px-4 py-2.5 text-sm transition-colors duration-200 ${
+              `flex items-center gap-3 px-4 py-2.5 text-sm transition-colors duration-200 border-l-2 ${
                 isActive
-                  ? 'bg-bg-elevated text-text-primary'
-                  : 'text-text-secondary hover:bg-bg-hover hover:text-text-primary'
+                  ? 'bg-[#1f1a0a] border-amber text-amber'
+                  : 'border-transparent text-text-secondary hover:bg-bg-hover hover:text-text-primary'
               }`
             }
           >

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -9,26 +9,45 @@ interface TopBarProps {
 function StatusDot({ up }: { up: boolean }) {
   return (
     <span
-      className={`inline-block w-2.5 h-2.5 rounded-full ${
+      className={`inline-block w-2 h-2 rounded-full shrink-0 ${
         up
-          ? 'bg-status-healthy animate-pulse-active'
+          ? 'bg-status-healthy animate-pulse-healthy'
           : 'bg-status-critical animate-pulse-critical'
       }`}
     />
   )
 }
 
+function Pill({
+  children,
+  onClick,
+  className = '',
+}: {
+  children: React.ReactNode
+  onClick?: () => void
+  className?: string
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={`flex items-center gap-1.5 rounded-full px-3 py-1 bg-bg-elevated border border-border-subtle hover:bg-bg-hover transition-colors shrink-0 ${className}`}
+    >
+      {children}
+    </button>
+  )
+}
+
 function UsageBar({ label, percent }: { label: string; percent: number | null }) {
   if (percent === null) return null
   const color =
-    percent > 85 ? 'bg-accent-red' : percent > 60 ? 'bg-accent-amber' : 'bg-status-healthy'
+    percent > 85 ? 'bg-red' : percent > 60 ? 'bg-amber' : 'bg-status-healthy'
   return (
     <div className="flex items-center gap-1.5 min-w-[100px]">
       <span className="text-xs text-text-secondary whitespace-nowrap">{label}</span>
-      <div className="flex-1 h-1.5 bg-bg-elevated rounded-full overflow-hidden">
+      <div className="flex-1 h-1.5 bg-bg-void rounded-full overflow-hidden">
         <div className={`h-full rounded-full ${color}`} style={{ width: `${percent}%` }} />
       </div>
-      <span className="text-xs text-text-tertiary w-8 text-right">{percent}%</span>
+      <span className="text-xs font-mono text-text-tertiary w-8 text-right">{percent}%</span>
     </div>
   )
 }
@@ -36,17 +55,15 @@ function UsageBar({ label, percent }: { label: string; percent: number | null })
 function TempDisplay({ temp }: { temp: number | null }) {
   if (temp === null) return null
   const color =
-    temp > 85 ? 'text-accent-red' : temp > 70 ? 'text-accent-amber' : 'text-text-secondary'
-  return <span className={`text-xs ${color}`}>{temp}°C</span>
+    temp > 85 ? 'text-red' : temp > 70 ? 'text-amber' : 'text-text-secondary'
+  return <span className={`text-xs font-mono ${color}`}>{temp}°C</span>
 }
 
 export default function TopBar({ status, onMenuToggle }: TopBarProps) {
   const navigate = useNavigate()
 
   return (
-    <header
-      className="h-[var(--topbar-height)] bg-bg-surface border-b border-border-subtle flex items-center px-3 gap-2 shrink-0 overflow-hidden"
-    >
+    <header className="h-[var(--topbar-height)] bg-bg-surface border-b border-border-subtle flex items-center px-3 gap-2 shrink-0 overflow-hidden">
       {/* Hamburger — mobile only */}
       <button
         onClick={onMenuToggle}
@@ -56,66 +73,58 @@ export default function TopBar({ status, onMenuToggle }: TopBarProps) {
         <span className="text-base leading-none">☰</span>
       </button>
 
-      {/* Gateway */}
-      <button
-        onClick={() => navigate('/system')}
-        className="flex items-center gap-1.5 hover:bg-bg-hover rounded px-1.5 py-1 transition-colors shrink-0"
-      >
+      {/* Gateway pill */}
+      <Pill onClick={() => navigate('/system')}>
         <StatusDot up={status?.gateway_up ?? false} />
         <span className="text-xs text-text-secondary">GW</span>
-      </button>
+      </Pill>
 
-      {/* Agents */}
-      <button
-        onClick={() => navigate('/agents')}
-        className="hidden sm:flex items-center gap-1.5 hover:bg-bg-hover rounded px-1.5 py-1 transition-colors shrink-0"
-      >
-        <span className="text-xs text-text-secondary">
-          Agents {status ? `${status.agents_alive}/${status.agents_total}` : '—'}
+      {/* Agents pill */}
+      <Pill onClick={() => navigate('/agents')} className="hidden sm:flex">
+        <span className={`inline-block w-2 h-2 rounded-full shrink-0 ${
+          status && status.agents_alive > 0 ? 'bg-status-healthy animate-pulse-healthy' : 'bg-text-disabled'
+        }`} />
+        <span className="text-xs text-text-secondary">Agents</span>
+        <span className="text-xs font-mono text-text-primary">
+          {status ? `${status.agents_alive}/${status.agents_total}` : '—'}
         </span>
-      </button>
+      </Pill>
 
-      {/* Active tasks */}
-      <button
-        onClick={() => navigate('/')}
-        className="hidden sm:flex items-center gap-1.5 hover:bg-bg-hover rounded px-1.5 py-1 transition-colors shrink-0"
-      >
-        <span className="text-xs text-text-secondary">
-          Active {status?.active_tasks ?? '—'}
+      {/* Active tasks pill */}
+      <Pill onClick={() => navigate('/')} className="hidden sm:flex">
+        <span className={`inline-block w-2 h-2 rounded-full shrink-0 ${
+          status && status.active_tasks > 0 ? 'bg-amber animate-pulse-active' : 'bg-text-disabled'
+        }`} />
+        <span className="text-xs text-text-secondary">Active</span>
+        <span className="text-xs font-mono text-text-primary">
+          {status?.active_tasks ?? '—'}
         </span>
-      </button>
+      </Pill>
 
-      {/* Blocked tasks */}
-      <button
-        onClick={() => navigate('/')}
-        className="hidden sm:flex items-center gap-1.5 hover:bg-bg-hover rounded px-1.5 py-1 transition-colors shrink-0"
-      >
-        <span
-          className={`text-xs ${
-            status && status.blocked_tasks > 0 ? 'text-accent-amber' : 'text-text-secondary'
-          }`}
-        >
-          Blocked {status?.blocked_tasks ?? '—'}
-        </span>
-      </button>
+      {/* Blocked tasks pill */}
+      {status && status.blocked_tasks > 0 && (
+        <Pill onClick={() => navigate('/')} className="hidden sm:flex">
+          <span className="inline-block w-2 h-2 rounded-full shrink-0 bg-red animate-pulse-critical" />
+          <span className="text-xs text-red">Blocked</span>
+          <span className="text-xs font-mono text-red">{status.blocked_tasks}</span>
+        </Pill>
+      )}
 
       <div className="flex-1" />
 
-      {/* CPU */}
-      <button
-        onClick={() => navigate('/system')}
-        className="hidden md:flex items-center gap-2 hover:bg-bg-hover rounded px-1.5 py-1 transition-colors shrink-0"
-      >
-        <span className="text-xs text-text-secondary">
-          CPU {status?.cpu_percent != null ? `${status.cpu_percent}%` : '—'}
+      {/* CPU pill */}
+      <Pill onClick={() => navigate('/system')} className="hidden md:flex">
+        <span className="text-xs text-text-secondary">CPU</span>
+        <span className="text-xs font-mono text-text-primary">
+          {status?.cpu_percent != null ? `${status.cpu_percent}%` : '—'}
         </span>
         <TempDisplay temp={status?.cpu_temp ?? null} />
-      </button>
+      </Pill>
 
       {/* Usage bars */}
       <button
         onClick={() => navigate('/config')}
-        className="hidden lg:flex items-center gap-3 hover:bg-bg-hover rounded px-1.5 py-1 transition-colors shrink-0"
+        className="hidden lg:flex items-center gap-3 hover:bg-bg-hover rounded-full px-3 py-1 transition-colors shrink-0"
       >
         <UsageBar label="Claude" percent={status?.claude_usage_percent ?? null} />
         <UsageBar label="Codex" percent={status?.codex_usage_percent ?? null} />

--- a/src/components/system/ServicesGrid.tsx
+++ b/src/components/system/ServicesGrid.tsx
@@ -58,8 +58,11 @@ export default function ServicesGrid({ services, loading, onAction }: ServicesGr
               {items.map((service) => (
                 <article
                   key={service.name}
-                  className={`rounded-md border border-border-default bg-bg-elevated p-3 transition-colors ${
-                    service.forbidden ? 'opacity-60' : 'hover:bg-bg-hover'
+                  className={`rounded-md border p-3 transition-colors ${
+                    service.forbidden ? 'opacity-60 border-border-default bg-bg-elevated' :
+                    service.status === 'active' ? 'border-emerald/20 bg-bg-elevated hover:bg-bg-hover animate-pulse-healthy' :
+                    service.status === 'failed' ? 'border-red/30 bg-bg-elevated animate-pulse-critical' :
+                    'border-border-default bg-bg-elevated hover:bg-bg-hover'
                   }`}
                 >
                   <div className="mb-3 flex items-start justify-between gap-3">
@@ -78,11 +81,11 @@ export default function ServicesGrid({ services, loading, onAction }: ServicesGr
                   <dl className="grid grid-cols-2 gap-3 text-xs">
                     <div>
                       <dt className="mb-1 font-mono uppercase tracking-wide text-text-tertiary">Uptime</dt>
-                      <dd className="text-text-secondary">{service.uptime ?? '—'}</dd>
+                      <dd className="font-mono text-text-secondary">{service.uptime ?? '—'}</dd>
                     </div>
                     <div>
                       <dt className="mb-1 font-mono uppercase tracking-wide text-text-tertiary">Memory</dt>
-                      <dd className="text-text-secondary">{service.memory_mb != null ? `${service.memory_mb} MB` : '—'}</dd>
+                      <dd className="font-mono text-text-secondary">{service.memory_mb != null ? `${service.memory_mb} MB` : '—'}</dd>
                     </div>
                   </dl>
 

--- a/src/index.css
+++ b/src/index.css
@@ -43,3 +43,12 @@
 ::-webkit-scrollbar-thumb:hover {
   @apply bg-text-tertiary;
 }
+
+/* Respect reduced motion preference */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -110,12 +110,16 @@ export default {
       },
       keyframes: {
         'pulse-glow': {
-          '0%, 100%': { boxShadow: '0 0 0 0 rgba(245,166,35,0)' },
-          '50%': { boxShadow: '0 0 8px 2px rgba(245,166,35,0.3)' },
+          '0%, 100%': { boxShadow: '0 0 4px rgba(245,166,35,0.2)' },
+          '50%': { boxShadow: '0 0 8px rgba(245,166,35,0.4)' },
         },
         'pulse-glow-critical': {
-          '0%, 100%': { boxShadow: '0 0 0 0 rgba(239,68,68,0)' },
-          '50%': { boxShadow: '0 0 8px 2px rgba(239,68,68,0.4)' },
+          '0%, 100%': { boxShadow: '0 0 4px rgba(255,69,58,0.3)' },
+          '50%': { boxShadow: '0 0 10px rgba(255,69,58,0.6)' },
+        },
+        'pulse-glow-healthy': {
+          '0%, 100%': { boxShadow: '0 0 4px rgba(52,199,89,0.2)' },
+          '50%': { boxShadow: '0 0 8px rgba(52,199,89,0.5)' },
         },
         shimmer: {
           '0%': { backgroundPosition: '-200% 0' },
@@ -133,6 +137,7 @@ export default {
       animation: {
         'pulse-active': 'pulse-glow 2.5s ease-in-out infinite',
         'pulse-critical': 'pulse-glow-critical 1.2s ease-in-out infinite',
+        'pulse-healthy': 'pulse-glow-healthy 3s ease-in-out infinite',
         skeleton: 'shimmer 1.8s linear infinite',
         'fade-in': 'fadeIn 150ms ease',
         'slide-in-right': 'slideInRight 200ms cubic-bezier(0.16,1,0.3,1)',


### PR DESCRIPTION
## Phase 2 Design System

### #38 — Monospace + Charcoal + TopBar pills
- TopBar items restyled as **pill indicators**: `rounded-full`, `bg-elevated`, `border-subtle`
- Each pill has colored **status dot** (healthy green, active amber, critical red, disabled gray)
- Data values use `font-mono` (agent counts, CPU%, temp, usage bars)
- Blocked pill only visible when count > 0 (red dot + red text)
- Warm charcoal tokens already applied from design-tokens.json (no cold grays found)

### #39 — Pulse indicators
- New `pulse-glow-healthy` keyframe: slow green breathe (3s cycle)
- **Services**: active = emerald border + healthy pulse, failed = red border + critical pulse (1.2s)
- **Agent dots**: active=amber, idle=green slow, dead=red fast, waiting/unknown=static
- **TopBar**: gateway/agents/tasks dots pulse based on state
- `@media (prefers-reduced-motion: reduce)` disables all animations
- Pure CSS keyframes, no JS intervals

### #46 — Sidebar + Agent stats
- Active nav item: `bg-[#1f1a0a]` (warm dark amber), `border-left: 2px solid #F5A623`, amber text+icon
- Hover state: distinct `bg-hover` without border (not confused with active)
- Agent stats: `in:N` → amber highlight when N>0, `dead:N` → red highlight when N>0, zero=dim

Build: clean ✅

Closes #38, #39, #46