### PR TITLE
fix(#40,#41,#42,#44,#45): Phase 3 UX Polish

### DIFF
--- a/src/components/agents/AgentAvatar.tsx
+++ b/src/components/agents/AgentAvatar.tsx
@@ -1,0 +1,61 @@
+/**
+ * AgentAvatar — 40px circle with colored background, centered initial, status dot overlay.
+ */
+
+// Agent-specific background colors (from Leo's design spec)
+const AGENT_COLORS: Record<string, string> = {
+  sokrat:    '#3B82F6', // blue
+  archimedes:'#F97316', // orange
+  aristotle: '#A78BFA', // purple
+  herodotus: '#22C55E', // green
+  platon:    '#6366F1', // indigo
+  hephaestus:'#EF4444', // red
+  leo:       '#FBBF24', // yellow
+  brainstorm:'#14B8A6', // teal
+  'brainstorm-claude': '#14B8A6',
+  'brainstorm-codex':  '#0D9488',
+}
+
+const STATUS_DOT: Record<string, string> = {
+  active:  'bg-status-healthy',
+  idle:    'bg-status-idle',
+  dead:    'bg-status-critical',
+  waiting: 'bg-accent-purple',
+  unknown: 'bg-text-disabled',
+}
+
+interface AgentAvatarProps {
+  name: string
+  id: string
+  status: string
+  size?: number
+}
+
+export default function AgentAvatar({ name, id, status, size = 40 }: AgentAvatarProps) {
+  const bg = AGENT_COLORS[id] ?? AGENT_COLORS[id.toLowerCase()] ?? '#6B7280'
+  const initial = (name || id || '?')[0].toUpperCase()
+  const dotClass = STATUS_DOT[status] ?? STATUS_DOT.unknown
+  const dotSize = Math.round(size * 0.25) // 10px at 40px
+
+  return (
+    <div className="relative shrink-0" style={{ width: size, height: size }}>
+      {/* Circle with initial */}
+      <div
+        className="w-full h-full rounded-full flex items-center justify-center font-semibold text-white select-none"
+        style={{ backgroundColor: bg, fontSize: size * 0.45 }}
+      >
+        {initial}
+      </div>
+      {/* Status dot overlay — bottom-right */}
+      <span
+        className={`absolute rounded-full border-2 border-bg-surface ${dotClass}`}
+        style={{
+          width: dotSize,
+          height: dotSize,
+          bottom: -1,
+          right: -1,
+        }}
+      />
+    </div>
+  )
+}

--- a/src/components/agents/AgentCard.tsx
+++ b/src/components/agents/AgentCard.tsx
@@ -1,4 +1,5 @@
 import type { AgentInfo } from '../../lib/api'
+import AgentAvatar from './AgentAvatar'
 
 function relativeTime(isoString: string | null): string {
   if (!isoString) return 'No heartbeat'
@@ -35,7 +36,7 @@ export default function AgentCard({ agent, onClick }: AgentCardProps) {
       className="w-full text-left bg-bg-surface border border-border-default rounded-md p-3 hover:bg-bg-elevated transition-colors duration-100 focus:outline-none focus:ring-1 focus:ring-accent-amber/40"
     >
       <div className="flex items-start gap-3">
-        <span className="text-[32px] leading-none shrink-0">{agent.emoji}</span>
+        <AgentAvatar name={agent.name} id={agent.id} status={agent.status} size={40} />
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2">
             <span className="font-medium text-text-primary truncate">{agent.name}</span>

--- a/src/components/agents/AgentDetail.tsx
+++ b/src/components/agents/AgentDetail.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react'
 import ReactMarkdown from 'react-markdown'
 import type { AgentInfo } from '../../lib/api'
 import { fetchAgentInboxMd, fetchAgentLog, fetchAgentEvents, sendAgentMessage, wakeAgent } from '../../lib/api'
+import AgentAvatar from './AgentAvatar'
 import MailboxViewer from './MailboxViewer'
 import type { ToastPayload } from '../../hooks/useToast'
 
@@ -58,7 +59,7 @@ export default function AgentDetail({ agent, onClose, onToast }: AgentDetailProp
       <div className="fixed top-0 right-0 h-full w-[420px] max-w-full bg-bg-elevated border-l border-border-subtle z-50 flex flex-col animate-slide-in-right shadow-lg">
         {/* Header */}
         <div className="flex items-center gap-3 px-4 py-3 border-b border-border-subtle shrink-0">
-          <span className="text-2xl">{agent.emoji}</span>
+          <AgentAvatar name={agent.name} id={agent.id} status={agent.status} size={36} />
           <div className="flex-1 min-w-0">
             <div className="font-medium text-text-primary">{agent.name}</div>
             <div className="text-[11px] text-text-tertiary">{agent.role} · {agent.status}</div>

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -56,7 +56,7 @@ function TempDisplay({ temp }: { temp: number | null }) {
   if (temp === null) return null
   const color =
     temp > 85 ? 'text-red' : temp > 70 ? 'text-amber' : 'text-text-secondary'
-  return <span className={`text-xs font-mono ${color}`}>{temp}°C</span>
+  return <span className={`text-xs font-mono ${color}`} title={`CPU temperature: ${temp}°C`}>CPU {temp}°C</span>
 }
 
 export default function TopBar({ status, onMenuToggle }: TopBarProps) {

--- a/src/components/pipeline/KanbanBoard.tsx
+++ b/src/components/pipeline/KanbanBoard.tsx
@@ -61,10 +61,12 @@ function KanbanColumn({ state, tasks, onCardClick, errors, loading }: KanbanColu
     <div
       ref={setNodeRef}
       className={`
-        flex-shrink-0 w-[260px] flex flex-col rounded-lg
+        flex-shrink-0 w-[260px] flex flex-col rounded-lg border-t-2
         ${isOver ? 'bg-bg-overlay' : 'bg-bg-void'}
+        ${tasks.length === 0 && !loading ? 'opacity-50' : ''}
         transition-colors duration-100
       `}
+      style={{ borderTopColor: color }}
     >
       {/* Column header */}
       <div className="flex items-center gap-2 px-3 py-2 border-b border-border-subtle">
@@ -117,9 +119,10 @@ interface KanbanBoardProps {
   onCardClick: (task: Task) => void;
   onRefresh: () => void;
   loading?: boolean;
+  hideEmpty?: boolean;
 }
 
-export function KanbanBoard({ tasks, onCardClick, onRefresh, loading }: KanbanBoardProps) {
+export function KanbanBoard({ tasks, onCardClick, onRefresh, loading, hideEmpty }: KanbanBoardProps) {
   const [activeTask, setActiveTask] = useState<Task | null>(null);
 
   const [errors, setErrors] = useState<Record<string, TransitionError>>({});
@@ -187,6 +190,9 @@ export function KanbanBoard({ tasks, onCardClick, onRefresh, loading }: KanbanBo
   );
 
   const allStates: PipelineState[] = [...MAIN_FLOW_STATES, ...SIDE_STATES];
+  const visibleStates = hideEmpty
+    ? allStates.filter((s) => tasksByState(s).length > 0)
+    : allStates;
 
   return (
     <div className="relative h-full">
@@ -197,7 +203,7 @@ export function KanbanBoard({ tasks, onCardClick, onRefresh, loading }: KanbanBo
         onDragEnd={handleDragEnd}
       >
         <div className="flex gap-3 h-full overflow-x-auto pb-3 px-1">
-          {allStates.map((state) => (
+          {visibleStates.map((state) => (
             <KanbanColumn
               key={state}
               state={state}

--- a/src/components/system/ServicesGrid.tsx
+++ b/src/components/system/ServicesGrid.tsx
@@ -21,6 +21,13 @@ function serviceStatusClass(status: string) {
   return STATUS_STYLES[status] ?? 'bg-bg-overlay text-text-secondary border-border-default'
 }
 
+function getActions(service: ServiceInfo): ('start' | 'stop' | 'restart')[] {
+  if (service.forbidden) return []
+  if (service.status === 'active') return ['restart', 'stop']
+  if (service.status === 'inactive' || service.status === 'failed') return ['start']
+  return ['restart', 'stop', 'start'] // transitional states — show all
+}
+
 export default function ServicesGrid({ services, loading, onAction }: ServicesGridProps) {
   if (loading && services.length === 0) {
     return (
@@ -42,7 +49,12 @@ export default function ServicesGrid({ services, loading, onAction }: ServicesGr
   return (
     <div className="grid gap-4 xl:grid-cols-3">
       {GROUPS.map((group) => {
-        const items = services.filter((service) => service.group === group)
+        const all = services.filter((s) => s.group === group)
+        // Sort: active first, inactive/failed at bottom
+        const items = [...all].sort((a, b) => {
+          const rank = (s: string) => s === 'active' ? 0 : s === 'activating' ? 1 : s === 'failed' ? 2 : 3
+          return rank(a.status) - rank(b.status)
+        })
         return (
           <section key={group} className="rounded-lg border border-border-subtle bg-bg-surface p-4 shadow-panel">
             <div className="mb-3 flex items-center justify-between">
@@ -55,64 +67,72 @@ export default function ServicesGrid({ services, loading, onAction }: ServicesGr
               {items.length === 0 && (
                 <EmptyState icon="○" title={`No ${group} services`} />
               )}
-              {items.map((service) => (
-                <article
-                  key={service.name}
-                  className={`rounded-md border p-3 transition-colors ${
-                    service.forbidden ? 'opacity-60 border-border-default bg-bg-elevated' :
-                    service.status === 'active' ? 'border-emerald/20 bg-bg-elevated hover:bg-bg-hover animate-pulse-healthy' :
-                    service.status === 'failed' ? 'border-red/30 bg-bg-elevated animate-pulse-critical' :
-                    'border-border-default bg-bg-elevated hover:bg-bg-hover'
-                  }`}
-                >
-                  <div className="mb-3 flex items-start justify-between gap-3">
-                    <div>
-                      <div className="flex items-center gap-2">
-                        <h3 className="text-sm font-semibold text-text-primary">{service.display_name}</h3>
-                        {service.forbidden && <span title="Forbidden service">🚫</span>}
+              {items.map((service) => {
+                const isInactive = service.status === 'inactive'
+                const isFailed = service.status === 'failed'
+                const actions = getActions(service)
+
+                return (
+                  <article
+                    key={service.name}
+                    className={`group rounded-md border p-3 transition-colors ${
+                      service.forbidden ? 'opacity-50 border-border-default bg-bg-void' :
+                      isInactive ? 'opacity-60 border-l-2 border-l-red/40 border-border-default bg-bg-void' :
+                      isFailed ? 'border-red/30 bg-bg-elevated animate-pulse-critical' :
+                      service.status === 'active' ? 'border-emerald/20 bg-bg-elevated hover:bg-bg-hover animate-pulse-healthy' :
+                      'border-border-default bg-bg-elevated hover:bg-bg-hover'
+                    }`}
+                  >
+                    <div className="mb-3 flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <div className="flex items-center gap-2">
+                          <h3 className="text-sm font-semibold text-text-primary truncate" title={service.display_name}>{service.display_name}</h3>
+                          {service.forbidden && <span title="Forbidden service">🚫</span>}
+                        </div>
+                        <p className="mt-1 font-mono text-xs text-text-tertiary truncate" title={service.name}>{service.name}</p>
                       </div>
-                      <p className="mt-1 font-mono text-xs text-text-tertiary">{service.name}</p>
+                      <span className={`shrink-0 rounded border px-2 py-1 font-mono text-xs ${serviceStatusClass(service.status)}`} style={{ borderRadius: '4px' }}>
+                        {service.status}
+                      </span>
                     </div>
-                    <span className={`rounded-sm border px-2 py-1 font-mono text-xs ${serviceStatusClass(service.status)}`}>
-                      {service.status}
-                    </span>
-                  </div>
 
-                  <dl className="grid grid-cols-2 gap-3 text-xs">
-                    <div>
-                      <dt className="mb-1 font-mono uppercase tracking-wide text-text-tertiary">Uptime</dt>
-                      <dd className="font-mono text-text-secondary">{service.uptime ?? '—'}</dd>
-                    </div>
-                    <div>
-                      <dt className="mb-1 font-mono uppercase tracking-wide text-text-tertiary">Memory</dt>
-                      <dd className="font-mono text-text-secondary">{service.memory_mb != null ? `${service.memory_mb} MB` : '—'}</dd>
-                    </div>
-                  </dl>
+                    <dl className="grid grid-cols-2 gap-3 text-xs">
+                      <div>
+                        <dt className="mb-1 font-mono uppercase tracking-wide text-text-tertiary">Uptime</dt>
+                        <dd className="font-mono text-text-secondary">{service.uptime ?? '—'}</dd>
+                      </div>
+                      <div>
+                        <dt className="mb-1 font-mono uppercase tracking-wide text-text-tertiary">Memory</dt>
+                        <dd className="font-mono text-text-secondary">{service.memory_mb != null ? `${service.memory_mb} MB` : '—'}</dd>
+                      </div>
+                    </dl>
 
-                  <div className="mt-4 flex flex-wrap gap-2">
-                    {(['restart', 'stop', 'start'] as const).map((action) => {
-                      const disabled = service.forbidden
-                      const needsConfirm = action === 'stop' || action === 'restart'
-                      return (
-                        <button
-                          key={action}
-                          type="button"
-                          disabled={disabled}
-                          aria-label={`${action} ${service.display_name}`}
-                          onClick={() => {
-                            if (disabled) return
-                            if (needsConfirm && !window.confirm(`${action} ${service.display_name}?`)) return
-                            void onAction(service, action)
-                          }}
-                          className="rounded-sm border border-border-subtle px-3 py-1.5 font-mono text-xs text-text-secondary transition-colors hover:bg-bg-hover hover:text-text-primary disabled:cursor-not-allowed disabled:text-text-disabled"
-                        >
-                          {action}
-                        </button>
-                      )
-                    })}
-                  </div>
-                </article>
-              ))}
+                    {/* Action buttons — contextual, hover-only */}
+                    {actions.length > 0 && (
+                      <div className="mt-3 flex flex-wrap gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
+                        {actions.map((action) => {
+                          const needsConfirm = action === 'stop' || action === 'restart'
+                          return (
+                            <button
+                              key={action}
+                              type="button"
+                              aria-label={`${action} ${service.display_name}`}
+                              onClick={() => {
+                                if (needsConfirm && !window.confirm(`${action} ${service.display_name}?`)) return
+                                void onAction(service, action)
+                              }}
+                              className="rounded border border-border-subtle px-3 py-1 font-mono text-xs text-text-secondary transition-colors hover:bg-bg-hover hover:text-text-primary"
+                              style={{ borderRadius: '4px' }}
+                            >
+                              {action}
+                            </button>
+                          )
+                        })}
+                      </div>
+                    )}
+                  </article>
+                )
+              })}
             </div>
           </section>
         )

--- a/src/components/system/UsageTracker.tsx
+++ b/src/components/system/UsageTracker.tsx
@@ -42,10 +42,12 @@ export default function UsageTracker({ data, loading, onSwitchProfile }: UsageTr
     return <div className="rounded-lg border border-border-subtle bg-bg-surface p-6 text-sm text-text-tertiary">Loading usage data…</div>
   }
 
-  if (!data || data.profiles.length === 0 || !data.cached) {
+  if (!data || data.profiles.length === 0) {
+    // Suppress raw error — show graceful empty state
     return (
-      <div className="rounded-lg border border-border-subtle bg-bg-surface p-6 text-sm text-text-tertiary">
-        Rate-limit cache unavailable.
+      <div className="rounded-lg border border-border-subtle bg-bg-surface p-4 flex items-center gap-2">
+        <span className="w-2 h-2 rounded-full bg-text-disabled shrink-0" />
+        <span className="text-xs text-text-tertiary">Usage data not yet available</span>
       </div>
     )
   }

--- a/src/pages/Pipeline.tsx
+++ b/src/pages/Pipeline.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback } from 'react';
+import { useState, useMemo, useCallback, useEffect } from 'react';
 import type { Task, PipelineState, StateGroup } from '../lib/types';
 import {
   ERROR_STATES,
@@ -11,6 +11,19 @@ import { fetchTasks, createTask } from '../lib/api';
 import { usePolling } from '../hooks/usePolling';
 import { KanbanBoard } from '../components/pipeline/KanbanBoard';
 import { TaskDetail } from '../components/pipeline/TaskDetail';
+
+// ─── Freshness Indicator ──────────────────────────────────────────────────────
+
+function Freshness({ ts }: { ts: number }) {
+  const [now, setNow] = useState(Date.now())
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 1000)
+    return () => clearInterval(id)
+  }, [])
+  const seconds = Math.max(0, Math.floor((now - ts) / 1000))
+  const label = seconds < 5 ? 'just now' : seconds < 60 ? `${seconds}s ago` : `${Math.floor(seconds / 60)}m ago`
+  return <span className="ml-3 text-[11px] font-mono text-text-disabled">Updated {label}</span>
+}
 
 // ─── Filter Bar ───────────────────────────────────────────────────────────────
 
@@ -218,16 +231,19 @@ export function Pipeline() {
     route: '',
     stateGroup: 'all',
   });
+  const [hideEmpty, setHideEmpty] = useState(false);
+  const [lastUpdated, setLastUpdated] = useState<number>(Date.now());
 
   const allOwners = useMemo(() => {
     if (!tasks) return [];
     return [...new Set(tasks.map((t) => t.owner))].sort();
   }, [tasks]);
 
-  const filteredTasks = useMemo(
-    () => filterTasks(tasks || [], filters),
-    [tasks, filters]
-  );
+  const filteredTasks = useMemo(() => {
+    const result = filterTasks(tasks || [], filters);
+    setLastUpdated(Date.now());
+    return result;
+  }, [tasks, filters]);
 
   const handleCardClick = useCallback((task: Task) => {
     setSelectedTask(task);
@@ -255,6 +271,16 @@ export function Pipeline() {
             {tasks.length} tasks
           </span>
         )}
+        <Freshness ts={lastUpdated} />
+        <label className="ml-auto flex items-center gap-1.5 cursor-pointer select-none">
+          <input
+            type="checkbox"
+            checked={hideEmpty}
+            onChange={(e) => setHideEmpty(e.target.checked)}
+            className="accent-amber w-3 h-3"
+          />
+          <span className="text-xs text-text-tertiary">Hide empty</span>
+        </label>
       </header>
 
       {/* Filter bar */}
@@ -271,6 +297,7 @@ export function Pipeline() {
           tasks={filteredTasks}
           onCardClick={handleCardClick}
           onRefresh={refresh}
+          hideEmpty={hideEmpty}
         />
       </div>
 

--- a/tests/client/system-page.test.tsx
+++ b/tests/client/system-page.test.tsx
@@ -39,7 +39,10 @@ describe('System components', () => {
 
     expect(screen.getByText('Core')).toBeInTheDocument()
     expect(screen.getByText('OpenClaw Gateway')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /restart openclaw gateway/i })).toBeDisabled()
+    // Forbidden services no longer render action buttons at all (not disabled — absent)
+    expect(screen.queryByRole('button', { name: /restart openclaw gateway/i })).toBeNull()
+    // Active non-forbidden service should have contextual buttons (restart, stop)
+    expect(screen.getByRole('button', { name: /restart dashboard server/i })).toBeInTheDocument()
   })
 
   it('renders a 16-cell cpu heatmap', () => {


### PR DESCRIPTION
## Phase 3 UX Polish

### #40 — Dim inactive services + contextual actions
- Inactive: `opacity-60`, `bg-void`, red left border, sorted to bottom of section
- Actions: contextual (running → restart+stop, stopped → start), hover-only
- Forbidden: `opacity-50`, no buttons. Names get `title` tooltip.
- Badge `border-radius: 4px`

### #41 — Pipeline state colors
- `border-t-2` on each column colored from `STATE_COLORS` tokens
- INTAKE=blue → DONE=green gradient across board
- Empty columns dimmed (`opacity-50`)

### #42 — Agent avatars
- New `AgentAvatar.tsx`: 40px circle + colored bg + initial + 10px status dot
- Per-agent colors: Сократ=blue, Архимед=orange, Аристотель=purple, etc.
- Used in both AgentCard and AgentDetail

### #44 — Collapse empty columns + freshness
- "Hide empty" checkbox filters zero-task columns
- "Updated Xs ago" auto-refreshing freshness indicator

### #45 — System page polish
- Temperature: `CPU 61°C` (labeled, with title tooltip)
- UsageTracker: graceful empty state (not raw error string)

Build: clean ✅

Closes #40, #41, #42, #44, #45