### PR TITLE
feat(#43,#47): Phase 4 — Config viewer + enhancements

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>AO Dashboard</title>
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🦉</text></svg>" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,12 +2,15 @@ import { useState } from 'react'
 import { Outlet } from 'react-router-dom'
 import TopBar from './components/layout/TopBar'
 import Sidebar from './components/layout/Sidebar'
+import ShortcutsModal from './components/layout/ShortcutsModal'
 import { usePolling } from './hooks/usePolling'
+import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts'
 import { getStatus } from './lib/api'
 
 export default function App() {
   const { data: status } = usePolling(getStatus, 5000)
   const [sidebarOpen, setSidebarOpen] = useState(false)
+  const { showHelp, setShowHelp, shortcuts } = useKeyboardShortcuts()
 
   return (
     <div className="h-screen flex flex-col overflow-hidden">
@@ -34,6 +37,11 @@ export default function App() {
           <Outlet />
         </main>
       </div>
+
+      {/* Keyboard shortcuts modal */}
+      {showHelp && (
+        <ShortcutsModal shortcuts={shortcuts} onClose={() => setShowHelp(false)} />
+      )}
     </div>
   )
 }

--- a/src/components/agents/AgentCard.tsx
+++ b/src/components/agents/AgentCard.tsx
@@ -1,5 +1,6 @@
 import type { AgentInfo } from '../../lib/api'
 import AgentAvatar from './AgentAvatar'
+import CopyButton from '../ui/CopyButton'
 
 function relativeTime(isoString: string | null): string {
   if (!isoString) return 'No heartbeat'
@@ -52,8 +53,9 @@ export default function AgentCard({ agent, onClick }: AgentCardProps) {
             </div>
 
             {agent.current_task_id && (
-              <div className="text-[11px] font-mono text-text-tertiary truncate">
-                {agent.current_task_id}
+              <div className="text-[11px] font-mono text-text-tertiary truncate flex items-center gap-1">
+                <span className="truncate">{agent.current_task_id}</span>
+                <CopyButton text={agent.current_task_id} className="shrink-0" />
               </div>
             )}
 

--- a/src/components/config/ConfigViewer.tsx
+++ b/src/components/config/ConfigViewer.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useMemo } from 'react'
 
 const SECTION_ORDER = ['agents', 'auth', 'memory', 'session', 'gateway', 'models', 'tools', 'hooks', 'channels', 'bindings', 'commands', 'skills', 'plugins', 'browser', 'meta', 'wizard']
 
@@ -6,13 +6,49 @@ function isRedacted(value: unknown): boolean {
   return value === '••••••••'
 }
 
-function ConfigValue({ label, value }: { label: string; value: unknown }) {
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false)
+  const handleCopy = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    navigator.clipboard.writeText(text).then(() => {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1500)
+    })
+  }
+  return (
+    <button
+      onClick={handleCopy}
+      className="opacity-0 group-hover/val:opacity-100 ml-1 px-1 text-text-disabled hover:text-text-secondary transition-opacity"
+      title="Copy to clipboard"
+    >
+      {copied ? '✓' : '⎘'}
+    </button>
+  )
+}
+
+function ValueDisplay({ value }: { value: unknown }) {
+  if (typeof value === 'boolean') {
+    return (
+      <span className={`inline-flex items-center px-1.5 py-0.5 rounded text-xs font-mono ${
+        value ? 'bg-emerald-subtle text-emerald' : 'bg-red-subtle text-red'
+      }`}>
+        {value ? 'true' : 'false'}
+      </span>
+    )
+  }
+  if (typeof value === 'number') {
+    return <span className="text-amber font-mono text-sm">{value}</span>
+  }
+  return <span className="text-text-primary font-mono text-sm break-all">{String(value)}</span>
+}
+
+function ConfigValue({ label, value, searchMatch }: { label: string; value: unknown; searchMatch?: boolean }) {
   if (value === null || value === undefined) return null
 
   if (isRedacted(value)) {
     return (
-      <div className="flex items-center gap-2 py-1">
-        <span className="text-text-secondary text-sm min-w-[180px] font-mono">{label}</span>
+      <div className="flex items-center gap-2 py-1 group/val">
+        <span className="text-text-secondary text-sm min-w-[180px] font-mono shrink-0">{label}</span>
         <span className="text-text-tertiary text-sm font-mono flex items-center gap-1">
           <svg className="w-3 h-3" viewBox="0 0 16 16" fill="currentColor">
             <path d="M8 1a4 4 0 0 0-4 4v3H3a1 1 0 0 0-1 1v5a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1V9a1 1 0 0 0-1-1h-1V5a4 4 0 0 0-4-4zm2 7H6V5a2 2 0 1 1 4 0v3z"/>
@@ -24,42 +60,46 @@ function ConfigValue({ label, value }: { label: string; value: unknown }) {
   }
 
   if (typeof value === 'object' && !Array.isArray(value)) {
-    return (
-      <ConfigSection label={label} data={value as Record<string, unknown>} nested />
-    )
+    return <ConfigSection label={label} data={value as Record<string, unknown>} nested />
   }
 
   if (Array.isArray(value)) {
     return (
-      <div className="flex items-start gap-2 py-1">
-        <span className="text-text-secondary text-sm min-w-[180px] font-mono">{label}</span>
-        <div className="flex flex-wrap gap-1">
+      <div className={`flex items-start gap-2 py-1 group/val ${searchMatch ? 'bg-amber-subtle/30 -mx-2 px-2 rounded' : ''}`}>
+        <span className="text-text-secondary text-sm min-w-[180px] font-mono shrink-0">{label}</span>
+        <div className="flex flex-wrap gap-1 min-w-0">
           {value.map((item, i) => (
-            <span key={i} className="bg-bg-surface text-text-secondary text-xs font-mono px-2 py-0.5 rounded-sm border border-border-subtle">
+            <span key={i} className="bg-bg-surface text-text-secondary text-xs font-mono px-2 py-0.5 rounded border border-border-subtle break-all" style={{ borderRadius: '4px' }}>
               {typeof item === 'object' ? JSON.stringify(item) : String(item)}
             </span>
           ))}
         </div>
+        <CopyButton text={JSON.stringify(value)} />
       </div>
     )
   }
 
-  const display = typeof value === 'boolean'
-    ? (value ? 'true' : 'false')
-    : String(value)
-
   return (
-    <div className="flex items-center gap-2 py-1">
-      <span className="text-text-secondary text-sm min-w-[180px] font-mono">{label}</span>
-      <span className={`text-sm font-mono ${typeof value === 'boolean' ? (value ? 'text-emerald' : 'text-text-tertiary') : 'text-text-primary'}`}>
-        {display}
-      </span>
+    <div className={`flex items-center gap-2 py-1 group/val ${searchMatch ? 'bg-amber-subtle/30 -mx-2 px-2 rounded' : ''}`}>
+      <span className="text-text-secondary text-sm min-w-[180px] font-mono shrink-0">{label}</span>
+      <ValueDisplay value={value} />
+      <CopyButton text={String(value)} />
     </div>
   )
 }
 
-function ConfigSection({ label, data, nested }: { label: string; data: Record<string, unknown>; nested?: boolean }) {
+function ConfigSection({ label, data, nested, filter }: { label: string; data: Record<string, unknown>; nested?: boolean; filter?: string }) {
   const [collapsed, setCollapsed] = useState(nested ?? false)
+
+  // If filter is active and this section has no matching keys/values, skip
+  const entries = Object.entries(data)
+  const hasMatch = !filter || entries.some(([k, v]) =>
+    k.toLowerCase().includes(filter) ||
+    String(v).toLowerCase().includes(filter) ||
+    (typeof v === 'object' && JSON.stringify(v).toLowerCase().includes(filter))
+  )
+
+  if (filter && !hasMatch) return null
 
   return (
     <div className={nested ? 'ml-4 border-l border-border-subtle pl-3 my-1' : 'mb-4'}>
@@ -77,17 +117,19 @@ function ConfigSection({ label, data, nested }: { label: string; data: Record<st
         <span className={`font-semibold ${nested ? 'text-sm text-text-secondary' : 'text-md text-amber'}`}>
           {label}
         </span>
-        {collapsed && (
-          <span className="text-xs text-text-tertiary">
-            {Object.keys(data).length} fields
-          </span>
-        )}
+        <span className="text-xs text-text-tertiary font-mono">
+          {entries.length} fields
+        </span>
       </button>
       {!collapsed && (
         <div className={nested ? 'mt-1' : 'mt-2 ml-5'}>
-          {Object.entries(data).map(([k, v]) => (
-            <ConfigValue key={k} label={k} value={v} />
-          ))}
+          {entries.map(([k, v]) => {
+            const matchesFilter = filter && (
+              k.toLowerCase().includes(filter) ||
+              String(v).toLowerCase().includes(filter)
+            )
+            return <ConfigValue key={k} label={k} value={v} searchMatch={!!matchesFilter} />
+          })}
         </div>
       )}
     </div>
@@ -98,6 +140,7 @@ export default function ConfigViewer() {
   const [config, setConfig] = useState<Record<string, unknown> | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
+  const [search, setSearch] = useState('')
 
   useEffect(() => {
     fetch('/api/config/gateway')
@@ -116,34 +159,40 @@ export default function ConfigViewer() {
       })
   }, [])
 
+  const filter = useMemo(() => search.trim().toLowerCase(), [search])
+
   if (loading) {
-    return (
-      <div className="text-text-tertiary text-sm animate-pulse">Loading config...</div>
-    )
+    return <div className="text-text-tertiary text-sm animate-pulse">Loading config...</div>
   }
 
   if (error) {
-    return (
-      <div className="text-ao-red text-sm">Error: {error}</div>
-    )
+    return <div className="text-red text-sm">Error: {error}</div>
   }
 
   if (!config) return null
 
-  // Order sections predictably
   const orderedKeys = SECTION_ORDER.filter(k => k in config)
   const extraKeys = Object.keys(config).filter(k => !SECTION_ORDER.includes(k))
   const allKeys = [...orderedKeys, ...extraKeys]
 
   return (
     <div className="max-w-4xl">
-      <p className="text-text-tertiary text-xs mb-4 font-mono">
-        ~/.openclaw/openclaw.json — read-only
-      </p>
+      {/* Search bar */}
+      <div className="flex items-center gap-3 mb-4">
+        <p className="text-text-tertiary text-xs font-mono">~/.openclaw/openclaw.json — read-only</p>
+        <input
+          type="text"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Filter config…"
+          className="ml-auto bg-bg-void border border-border-default text-text-primary text-xs font-mono px-3 py-1.5 rounded-sm w-48 focus:border-amber focus:outline-none"
+        />
+      </div>
+
       {allKeys.map(key => {
         const value = config[key]
         if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
-          return <ConfigSection key={key} label={key} data={value as Record<string, unknown>} />
+          return <ConfigSection key={key} label={key} data={value as Record<string, unknown>} filter={filter || undefined} />
         }
         return <ConfigValue key={key} label={key} value={value} />
       })}

--- a/src/components/layout/ShortcutsModal.tsx
+++ b/src/components/layout/ShortcutsModal.tsx
@@ -1,0 +1,30 @@
+import type { Shortcut } from '../../hooks/useKeyboardShortcuts'
+
+interface Props {
+  shortcuts: Shortcut[]
+  onClose: () => void
+}
+
+export default function ShortcutsModal({ shortcuts, onClose }: Props) {
+  return (
+    <>
+      <div className="fixed inset-0 bg-black/50 z-50" onClick={onClose} />
+      <div className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-50 w-[360px] bg-bg-elevated border border-border-subtle rounded-lg shadow-panel animate-fade-in">
+        <div className="flex items-center justify-between px-4 py-3 border-b border-border-subtle">
+          <h2 className="text-sm font-semibold text-text-primary">Keyboard Shortcuts</h2>
+          <button onClick={onClose} className="text-text-tertiary hover:text-text-primary text-sm">Esc</button>
+        </div>
+        <div className="p-4 space-y-2">
+          {shortcuts.map((s) => (
+            <div key={s.keys} className="flex items-center justify-between">
+              <span className="text-sm text-text-secondary">{s.description}</span>
+              <kbd className="font-mono text-xs bg-bg-void border border-border-subtle rounded px-2 py-0.5 text-text-primary">
+                {s.keys}
+              </kbd>
+            </div>
+          ))}
+        </div>
+      </div>
+    </>
+  )
+}

--- a/src/components/pipeline/TaskCard.tsx
+++ b/src/components/pipeline/TaskCard.tsx
@@ -1,6 +1,7 @@
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import type { Task, TransitionError } from '../../lib/types';
+import CopyButton from '../ui/CopyButton';
 
 function timeAgo(minutes: number | null): string {
   if (minutes === null || minutes === undefined) return '—';
@@ -52,8 +53,9 @@ export function TaskCard({ task, onClick, error }: TaskCardProps) {
         </p>
 
         {/* Task ID */}
-        <p className="font-mono text-xs text-text-tertiary mt-1">
-          {task.id}
+        <p className="font-mono text-xs text-text-tertiary mt-1 flex items-center gap-1">
+          <span>{task.id}</span>
+          <CopyButton text={task.id} />
         </p>
 
         {/* Badges row */}

--- a/src/components/ui/CopyButton.tsx
+++ b/src/components/ui/CopyButton.tsx
@@ -1,0 +1,28 @@
+import { useState } from 'react'
+
+interface CopyButtonProps {
+  text: string
+  className?: string
+}
+
+export default function CopyButton({ text, className = '' }: CopyButtonProps) {
+  const [copied, setCopied] = useState(false)
+
+  const handleCopy = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    navigator.clipboard.writeText(text).then(() => {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1500)
+    })
+  }
+
+  return (
+    <button
+      onClick={handleCopy}
+      className={`opacity-0 group-hover:opacity-100 text-text-disabled hover:text-text-secondary transition-opacity text-xs ${className}`}
+      title="Copy to clipboard"
+    >
+      {copied ? '✓' : '⎘'}
+    </button>
+  )
+}

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,66 @@
+import { useEffect, useState, useCallback } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+export interface Shortcut {
+  keys: string
+  description: string
+  action: () => void
+}
+
+export function useKeyboardShortcuts() {
+  const navigate = useNavigate()
+  const [showHelp, setShowHelp] = useState(false)
+  const [pendingG, setPendingG] = useState(false)
+
+  const shortcuts: Shortcut[] = [
+    { keys: 'g p', description: 'Go to Pipeline', action: () => navigate('/') },
+    { keys: 'g a', description: 'Go to Agents', action: () => navigate('/agents') },
+    { keys: 'g s', description: 'Go to System', action: () => navigate('/system') },
+    { keys: 'g l', description: 'Go to Logs', action: () => navigate('/logs') },
+    { keys: 'g c', description: 'Go to Config', action: () => navigate('/config') },
+    { keys: '?', description: 'Show shortcuts', action: () => setShowHelp(true) },
+    { keys: 'Esc', description: 'Close panel / modal', action: () => setShowHelp(false) },
+  ]
+
+  const handleKey = useCallback((e: KeyboardEvent) => {
+    // Ignore when typing in input/textarea/select
+    const tag = (e.target as HTMLElement)?.tagName
+    if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return
+
+    if (e.key === 'Escape') {
+      setShowHelp(false)
+      setPendingG(false)
+      return
+    }
+
+    if (e.key === '?') {
+      e.preventDefault()
+      setShowHelp(prev => !prev)
+      return
+    }
+
+    if (pendingG) {
+      setPendingG(false)
+      const map: Record<string, string> = { p: '/', a: '/agents', s: '/system', l: '/logs', c: '/config' }
+      if (map[e.key]) {
+        e.preventDefault()
+        navigate(map[e.key])
+      }
+      return
+    }
+
+    if (e.key === 'g') {
+      setPendingG(true)
+      // Reset after 1s if no second key
+      setTimeout(() => setPendingG(false), 1000)
+      return
+    }
+  }, [pendingG, navigate])
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleKey)
+    return () => window.removeEventListener('keydown', handleKey)
+  }, [handleKey])
+
+  return { showHelp, setShowHelp, shortcuts }
+}


### PR DESCRIPTION
## Phase 4 — Final Phase

### #43 — Config viewer
- **Search/filter**: case-insensitive input, matching fields highlighted with amber background
- **Value types**: numbers=amber, booleans=green/red badges, strings=white, arrays=bordered chips
- **CopyButton** on all values (hover to reveal ⎘, click → ✓ for 1.5s)
- Sections show field count, all collapsible

### #47 — Enhancements (E-1 through E-5)

| Enhancement | Status |
|-------------|--------|
| E-1 Favicon | 🦉 SVG data URI in index.html ✅ |
| E-2 Keyboard shortcuts | `?`=help modal, `g+p/a/s/l/c`=navigate, `Esc`=close ✅ |
| E-3 Collapsible sidebar | Already implemented (toggle + localStorage) ✅ |
| E-4 Last-seen indicator | Already implemented (relativeTime in AgentCard) ✅ |
| E-5 Copy buttons | CopyButton.tsx on task_id (TaskCard), current_task_id (AgentCard), config values ✅ |

### New files
- `src/hooks/useKeyboardShortcuts.ts` — keyboard handler + state
- `src/components/layout/ShortcutsModal.tsx` — ? help overlay
- `src/components/ui/CopyButton.tsx` — reusable copy-to-clipboard

Build: clean ✅ | Tests: 23/23 ✅

Closes #43, #47