### PR TITLE
fix(#57): remove double /api prefix from fetchJson calls

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -280,20 +280,20 @@ export interface LogEvent {
 }
 
 export function getGatewayLog(lines = 200): Promise<GatewayLogResponse> {
-  return fetchJson<GatewayLogResponse>(`/api/logs/gateway?lines=${lines}`)
+  return fetchJson<GatewayLogResponse>(`/logs/gateway?lines=${lines}`)
 }
 export function getWorkerList(): Promise<WorkerListResponse> {
-  return fetchJson<WorkerListResponse>('/api/logs/worker')
+  return fetchJson<WorkerListResponse>('/logs/worker')
 }
 export function getWorkerLog(name: string, lines = 100): Promise<WorkerLogResponse> {
-  return fetchJson<WorkerLogResponse>(`/api/logs/worker/${encodeURIComponent(name)}?lines=${lines}`)
+  return fetchJson<WorkerLogResponse>(`/logs/worker/${encodeURIComponent(name)}?lines=${lines}`)
 }
 export function getDecisions(params?: { agent?: string; task_id?: string }): Promise<Decision[]> {
   const sp = new URLSearchParams()
   if (params?.agent) sp.set('agent', params.agent)
   if (params?.task_id) sp.set('task_id', params.task_id)
   const qs = sp.toString()
-  return fetchJson<Decision[]>(`/api/decisions${qs ? `?${qs}` : ''}`)
+  return fetchJson<Decision[]>(`/decisions${qs ? `?${qs}` : ''}`)
 }
 export function getLogEvents(params?: { agent?: string; task_id?: string; type?: string }): Promise<LogEvent[]> {
   const sp = new URLSearchParams()
@@ -301,7 +301,7 @@ export function getLogEvents(params?: { agent?: string; task_id?: string; type?:
   if (params?.task_id) sp.set('task_id', params.task_id)
   if (params?.type) sp.set('type', params.type)
   const qs = sp.toString()
-  return fetchJson<LogEvent[]>(`/api/events${qs ? `?${qs}` : ''}`)
+  return fetchJson<LogEvent[]>(`/events${qs ? `?${qs}` : ''}`)
 }
 
 // Aliases for backwards-compat with Logs components

--- a/tests/client/api-path-prefix.test.ts
+++ b/tests/client/api-path-prefix.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import {
+  getDecisions,
+  getGatewayLog,
+  getLogEvents,
+  getWorkerList,
+  getWorkerLog,
+} from '../../src/lib/api'
+
+function jsonResponse<T>(payload: T): Response {
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+describe('api path prefix contract', () => {
+  const fetchMock = vi.fn()
+
+  beforeEach(() => {
+    fetchMock.mockReset()
+    vi.stubGlobal('fetch', fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('composes endpoint URLs with exactly one /api prefix', async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ lines: [], file_size_bytes: 0, file_date: '2026-03-26' }))
+      .mockResolvedValueOnce(jsonResponse({ files: [] }))
+      .mockResolvedValueOnce(jsonResponse({ lines: [], file_size_bytes: 0, file_name: 'worker.log' }))
+      .mockResolvedValueOnce(jsonResponse([]))
+      .mockResolvedValueOnce(jsonResponse([]))
+
+    await getGatewayLog(50)
+    await getWorkerList()
+    await getWorkerLog('worker 1', 20)
+    await getDecisions({ agent: 'codex', task_id: 'task-1' })
+    await getLogEvents({ agent: 'codex', task_id: 'task-1', type: 'STATE_CHANGED' })
+
+    const urls = fetchMock.mock.calls.map(([url]) => String(url))
+
+    expect(urls).toEqual([
+      '/api/logs/gateway?lines=50',
+      '/api/logs/worker',
+      '/api/logs/worker/worker%201?lines=20',
+      '/api/decisions?agent=codex&task_id=task-1',
+      '/api/events?agent=codex&task_id=task-1&type=STATE_CHANGED',
+    ])
+
+    urls.forEach((url) => {
+      expect(url).not.toContain('/api/api/')
+    })
+  })
+
+  it('keeps fetchJson call paths base-relative (no /api prefix)', () => {
+    const source = readFileSync(resolve(__dirname, '../../src/lib/api.ts'), 'utf8')
+    expect(source).not.toMatch(/fetchJson\s*(?:<[^>]+>)?\(\s*[`'"]\/api/)
+  })
+})


### PR DESCRIPTION
## Summary
Fixes #57 — all API calls returned HTML instead of JSON due to double `/api/api/` prefix.

## Changes
- **src/lib/api.ts**: Removed `/api` prefix from 5 fetchJson call paths (`/logs/gateway`, `/logs/worker`, `/logs/worker/:name`, `/decisions`, `/events`). `fetchJson` already prepends `BASE='/api'`, so paths must be base-relative.
- **tests/client/api-path-prefix.test.ts**: New test suite (2 tests) — verifies no fetchJson call starts with `/api` prefix, and all composed URLs have exactly one `/api` prefix.

## Verification
- `npm run build`: ✅ clean
- `npm test`: ✅ 25/25 passing
- Verified: `grep -c "fetchJson.*'/api/" src/lib/api.ts` = 0

Closes #57