### PR TITLE
fix(#59-#62): responsive layout — System, Logs, Cron, Config

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,7 +33,7 @@ export default function App() {
         >
           <Sidebar status={status} onClose={() => setSidebarOpen(false)} />
         </div>
-        <main className="flex-1 overflow-auto p-3 md:p-6 min-w-0">
+        <main className="flex-1 overflow-y-auto overflow-x-hidden p-3 md:p-6 min-w-0">
           <Outlet />
         </main>
       </div>

--- a/src/components/config/ConfigViewer.tsx
+++ b/src/components/config/ConfigViewer.tsx
@@ -31,8 +31,8 @@ function ConfigValue({ label, value, searchMatch }: { label: string; value: unkn
 
   if (isRedacted(value)) {
     return (
-      <div className="flex items-center gap-2 py-1 group">
-        <span className="text-text-secondary text-sm min-w-[180px] font-mono shrink-0">{label}</span>
+      <div className="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-2 py-1 group">
+        <span className="text-text-secondary text-sm sm:min-w-[180px] font-mono sm:shrink-0">{label}</span>
         <span className="text-text-tertiary text-sm font-mono flex items-center gap-1">
           <svg className="w-3 h-3" viewBox="0 0 16 16" fill="currentColor">
             <path d="M8 1a4 4 0 0 0-4 4v3H3a1 1 0 0 0-1 1v5a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1V9a1 1 0 0 0-1-1h-1V5a4 4 0 0 0-4-4zm2 7H6V5a2 2 0 1 1 4 0v3z"/>
@@ -49,9 +49,9 @@ function ConfigValue({ label, value, searchMatch }: { label: string; value: unkn
 
   if (Array.isArray(value)) {
     return (
-      <div className={`flex items-start gap-2 py-1 group ${searchMatch ? 'bg-amber-subtle/30 -mx-2 px-2 rounded' : ''}`}>
-        <span className="text-text-secondary text-sm min-w-[180px] font-mono shrink-0">{label}</span>
-        <div className="flex flex-wrap gap-1 min-w-0">
+      <div className={`flex flex-col sm:flex-row sm:items-start gap-1 sm:gap-2 py-1 group ${searchMatch ? 'bg-amber-subtle/30 -mx-2 px-2 rounded' : ''}`}>
+        <span className="text-text-secondary text-sm sm:min-w-[180px] font-mono sm:shrink-0">{label}</span>
+        <div className="flex flex-wrap gap-1 min-w-0 overflow-x-auto max-w-full">
           {value.map((item, i) => (
             <span key={i} className="bg-bg-surface text-text-secondary text-xs font-mono px-2 py-0.5 rounded border border-border-subtle break-all" style={{ borderRadius: '4px' }}>
               {typeof item === 'object' ? JSON.stringify(item) : String(item)}
@@ -64,10 +64,12 @@ function ConfigValue({ label, value, searchMatch }: { label: string; value: unkn
   }
 
   return (
-    <div className={`flex items-center gap-2 py-1 group ${searchMatch ? 'bg-amber-subtle/30 -mx-2 px-2 rounded' : ''}`}>
-      <span className="text-text-secondary text-sm min-w-[180px] font-mono shrink-0">{label}</span>
-      <ValueDisplay value={value} />
-      <CopyButton text={String(value)} />
+    <div className={`flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-2 py-1 group ${searchMatch ? 'bg-amber-subtle/30 -mx-2 px-2 rounded' : ''}`}>
+      <span className="text-text-secondary text-sm sm:min-w-[180px] font-mono sm:shrink-0">{label}</span>
+      <div className="flex items-center gap-1 min-w-0 overflow-hidden">
+        <ValueDisplay value={value} />
+        <CopyButton text={String(value)} />
+      </div>
     </div>
   )
 }

--- a/src/components/logs/LogViewer.tsx
+++ b/src/components/logs/LogViewer.tsx
@@ -144,7 +144,7 @@ export default function LogViewer({ lines, loading, error, paused }: LogViewerPr
         <div
           ref={parentRef}
           onScroll={handleScroll}
-          className="flex-1 overflow-auto font-mono text-xs"
+          className="flex-1 overflow-auto font-mono text-xs max-w-full"
         >
           {filteredLines.length === 0 && !loading && !error ? (
             <div className="flex-1 flex items-center justify-center">

--- a/src/components/system/CronCalendar.tsx
+++ b/src/components/system/CronCalendar.tsx
@@ -127,9 +127,9 @@ export default function CronCalendar({ entries, loading, saving = false, onEntri
         {saving && <span className="font-mono text-xs text-amber">Saving…</span>}
       </div>
 
-      <div className="overflow-x-auto">
+      <div className="overflow-x-auto max-w-full relative">
         <div className="grid min-w-[920px] grid-cols-[72px_repeat(7,minmax(110px,1fr))]">
-          <div className="border-r border-border-subtle bg-bg-base" />
+          <div className="border-r border-border-subtle bg-bg-base sticky left-0 z-10" />
           {DAYS.map((day) => (
             <div key={day} className="border-b border-r border-border-subtle bg-bg-base px-3 py-2 text-center font-mono text-xs text-text-secondary last:border-r-0">
               {day}
@@ -138,7 +138,7 @@ export default function CronCalendar({ entries, loading, saving = false, onEntri
 
           {HOURS.map((hour) => (
             <div key={hour} className="contents">
-              <div className="border-r border-border-subtle px-3 py-2 font-mono text-xs text-text-tertiary">
+              <div className="border-r border-border-subtle px-3 py-2 font-mono text-xs text-text-tertiary sticky left-0 bg-bg-base z-10">
                 {hour.toString().padStart(2, '0')}:00
               </div>
               {DAYS.map((_, dayIndex) => (

--- a/src/components/system/ServicesGrid.tsx
+++ b/src/components/system/ServicesGrid.tsx
@@ -96,7 +96,7 @@ export default function ServicesGrid({ services, loading, onAction }: ServicesGr
                       </span>
                     </div>
 
-                    <dl className="grid grid-cols-2 gap-3 text-xs">
+                    <dl className="grid grid-cols-1 sm:grid-cols-2 gap-3 text-xs">
                       <div>
                         <dt className="mb-1 font-mono uppercase tracking-wide text-text-tertiary">Uptime</dt>
                         <dd className="font-mono text-text-secondary">{service.uptime ?? '—'}</dd>


### PR DESCRIPTION
## Summary
Fixes 4 responsive issues from Leo's audit (all CSS-only, zero logic changes):

### #59 — System page overflow ≤1024px (P0)
- `<main>` gets `overflow-x-hidden` (prevents page-level horizontal scroll)
- ServicesGrid `grid-cols-2` → `grid-cols-1 sm:grid-cols-2` (single column on mobile)

### #60 — Logs/Gateway overflow 390px (P0)
- LogViewer container gets `max-w-full` for containment
- Shared `<main>` overflow-x-hidden fix

### #61 — Cron Calendar columns clipped 768-1024px (P1)
- Scroll wrapper gets `max-w-full` to ensure proper containment
- Time column (hours) made sticky (`sticky left-0 z-10 bg-bg-base`) — stays visible while scrolling
- Header spacer also made sticky

### #62 — Config JSON unreadable ≤640px (P1)
- All key/value rows: `flex-col` at mobile, `sm:flex-row` at ≥640px
- Labels: `min-w-[180px]` → `sm:min-w-[180px]` (allows shrinking on mobile)
- Array values: `overflow-x-auto max-w-full` for long JSON containment

## Verification
- `npm run build`: ✅ clean
- `npm test`: ✅ 25/25 passing
- No logic changes

Closes #59, closes #60, closes #61, closes #62