### PR TITLE
fix: agent skills from config, pipeline endpoint, OrgChart hierarchy

### DIFF
--- a/server/api/agents.js
+++ b/server/api/agents.js
@@ -61,12 +61,21 @@ function deriveStatus(heartbeat) {
   return 'idle'
 }
 
+function configIdFor(agentId) {
+  if (agentId === 'sokrat') return 'main'
+  return agentId
+}
+
 // GET /api/agents
 router.get('/', async (_req, res) => {
   try {
+    const config = await safeReadJson(OPENCLAW_CONFIG)
+    const configList = config?.agents?.list ?? []
+
     const agents = await Promise.all(
       AGENT_META.map(async (meta) => {
         const heartbeat = await safeReadJson(join(HEARTBEATS_DIR, `${meta.id}.json`))
+        const configAgent = configList.find(a => a.id === configIdFor(meta.id))
         const mailbox = {
           inbox:      await countFiles(join(MAILBOXES_DIR, meta.id, 'inbox')),
           processing: await countFiles(join(MAILBOXES_DIR, meta.id, 'processing')),
@@ -85,7 +94,8 @@ router.get('/', async (_req, res) => {
           checkpoint_safe: heartbeat?.checkpoint_safe ?? null,
           last_seen: heartbeat?.updated_at ?? null,
           workspace_path: heartbeat?.workspace_path ?? null,
-          model: heartbeat?.model ?? null,
+          model: configAgent?.model?.primary ?? configAgent?.model ?? heartbeat?.model ?? null,
+          skills: configAgent?.skills ?? [],
           mailbox,
         }
       })

--- a/server/api/pipeline.js
+++ b/server/api/pipeline.js
@@ -1,0 +1,118 @@
+import { Router } from 'express'
+import { readFile, readdir } from 'fs/promises'
+import { join } from 'path'
+
+const router = Router()
+const HOME = process.env.HOME || '/home/aiadmin'
+const TODO_PATH = join(HOME, 'clawd/memory/tasks/TODO.md')
+const TASKS_ACTIVE_DIR = join(HOME, 'clawd/tasks/active')
+
+const SECTION_STATUS_MAP = {
+  blocked: 'blocked',
+  in_progress: 'in_progress',
+  'in progress': 'in_progress',
+  open_questions: 'open_questions',
+  'open questions': 'open_questions',
+  done: 'done',
+  completed: 'done',
+}
+
+function sectionToStatus(title) {
+  const lower = title.toLowerCase().replace(/[^a-z\s_]/g, '').trim()
+  for (const [key, val] of Object.entries(SECTION_STATUS_MAP)) {
+    if (lower.includes(key)) return val
+  }
+  return 'open'
+}
+
+function parseTodo(raw) {
+  const lines = raw.split('\n')
+  const items = []
+  let currentSection = 'open'
+  let counter = 1
+
+  for (const line of lines) {
+    // Section header: ## emoji Title
+    const sectionMatch = line.match(/^##\s+(.+)$/)
+    if (sectionMatch) {
+      currentSection = sectionToStatus(sectionMatch[1])
+      continue
+    }
+
+    // List item: - [x], - [ ], - [!]
+    const itemMatch = line.match(/^-\s+\[([x !])\]\s+(.+)$/)
+    if (!itemMatch) continue
+
+    const checkbox = itemMatch[1]
+    const rest = itemMatch[2]
+
+    // Extract title from **bold** text
+    const boldMatch = rest.match(/\*\*(.+?)\*\*/)
+    const title = boldMatch ? boldMatch[1] : rest.trim()
+    const description = rest.replace(/\*\*.+?\*\*/, '').trim() || null
+
+    const status = checkbox === 'x' ? 'completed' : checkbox === '!' ? 'blocked' : 'pending'
+    const id = `todo_${String(counter).padStart(3, '0')}`
+    counter++
+
+    items.push({ id, title, description, status, checkbox, section: currentSection })
+  }
+
+  return items
+}
+
+function parseYaml(raw) {
+  const result = {}
+  for (const line of raw.split('\n')) {
+    const match = line.match(/^(\w+):\s*(.+)$/)
+    if (match) {
+      result[match[1]] = match[2].trim().replace(/^["']|["']$/g, '')
+    }
+  }
+  return result
+}
+
+// GET /api/pipeline
+router.get('/', async (_req, res) => {
+  try {
+    const items = []
+
+    // Read TODO.md
+    try {
+      const raw = await readFile(TODO_PATH, 'utf-8')
+      items.push(...parseTodo(raw))
+    } catch {
+      // file may not exist
+    }
+
+    // Read active task YAML files
+    try {
+      const files = await readdir(TASKS_ACTIVE_DIR)
+      for (const file of files) {
+        if (!file.endsWith('.yaml') && !file.endsWith('.yml')) continue
+        try {
+          const raw = await readFile(join(TASKS_ACTIVE_DIR, file), 'utf-8')
+          const parsed = parseYaml(raw)
+          items.push({
+            id: parsed.id ?? file.replace(/\.ya?ml$/, ''),
+            title: parsed.title ?? file,
+            status: parsed.status ?? 'pending',
+            owner: parsed.owner ?? null,
+            priority: parsed.priority ?? null,
+            source: 'task-store',
+          })
+        } catch {
+          // skip unparseable files
+        }
+      }
+    } catch {
+      // directory may not exist
+    }
+
+    res.json(items)
+  } catch (err) {
+    res.status(500).json({ error: err.message })
+  }
+})
+
+export default router

--- a/server/index.js
+++ b/server/index.js
@@ -15,6 +15,7 @@ import servicesRouter from './api/services.js'
 import cronRouter from './api/cron.js'
 import vitalsRouter from './api/vitals.js'
 import ideasRouter from './api/ideas.js'
+import pipelineRouter from './api/pipeline.js'
 import { getGlobalStatus } from './lib/status.js'
 import { startVitalsWorker } from './lib/vitals.js'
 
@@ -50,6 +51,7 @@ app.use('/api/config', configRouter)
 app.use('/api/memory', memoryRouter)
 app.use('/api/skills', skillsRouter)
 app.use('/api/ideas', ideasRouter)
+app.use('/api/pipeline', pipelineRouter)
 
 
 

--- a/src/components/agents/OrgChart.tsx
+++ b/src/components/agents/OrgChart.tsx
@@ -9,20 +9,103 @@ interface OrgChartProps {
   onSelectAgent: (agent: AgentInfo) => void
 }
 
-function findRoot(agents: AgentInfo[]): AgentInfo | undefined {
-  return (
-    agents.find(a => a.role === 'orchestrator') ??
-    agents.find(a => a.name === 'main') ??
-    agents[0]
-  )
+const HIERARCHY: Record<string, string | null> = {
+  sokrat: null,
+  aristotle: 'sokrat',
+  herodotus: 'sokrat',
+  'brainstorm-claude': 'sokrat',
+  'brainstorm-codex': 'sokrat',
+  platon: 'sokrat',
+  leo: 'platon',
+  hephaestus: 'sokrat',
+  archimedes: 'hephaestus',
 }
 
-/** Horizontal connector line constants */
+interface TreeNode {
+  agent: AgentInfo
+  children: TreeNode[]
+}
+
+function buildTree(agents: AgentInfo[]): TreeNode | null {
+  const rootId = Object.entries(HIERARCHY).find(([, parent]) => parent === null)?.[0]
+  // Find root agent — by hierarchy id, or fallback to orchestrator role, or first agent
+  const rootAgent = (rootId ? agents.find(a => a.id === rootId) : null)
+    ?? agents.find(a => a.role === 'orchestrator' || a.role === 'Orchestrator')
+    ?? agents[0]
+  if (!rootAgent) return null
+
+  function buildNode(agent: AgentInfo, allAgents: AgentInfo[]): TreeNode {
+    // Children defined by HIERARCHY
+    const hierarchyChildIds = Object.entries(HIERARCHY)
+      .filter(([, parent]) => parent === agent.id)
+      .map(([childId]) => childId)
+    const hierarchyChildren = hierarchyChildIds
+      .map(childId => allAgents.find(a => a.id === childId))
+      .filter((a): a is AgentInfo => a != null)
+      .map(a => buildNode(a, allAgents))
+    return { agent, children: hierarchyChildren }
+  }
+
+  const tree = buildNode(rootAgent, agents)
+
+  // Collect all agent ids rendered in the tree
+  const renderedIds = new Set<string>()
+  function collectIds(node: TreeNode) {
+    renderedIds.add(node.agent.id)
+    node.children.forEach(collectIds)
+  }
+  collectIds(tree)
+
+  // Attach any agents not rendered as direct children of root
+  const orphans = agents.filter(a => !renderedIds.has(a.id))
+  for (const orphan of orphans) {
+    tree.children.push({ agent: orphan, children: [] })
+  }
+
+  return tree
+}
+
+/** Layout constants */
 const ROOT_W = 80
 const ROOT_H = 100
-const CHILD_R = 24 // child circle radius
-const CHILD_ROW_H = 64 // vertical spacing per child
-const GAP_X = 60 // horizontal gap between root edge and child centers
+const CHILD_DIAMETER = 48
+const CHILD_R = CHILD_DIAMETER / 2
+const CHILD_ROW_H = 64
+const GAP_X = 60
+
+function getSubtreeHeight(node: TreeNode): number {
+  if (node.children.length === 0) return CHILD_ROW_H
+  return node.children.reduce((sum, child) => sum + getSubtreeHeight(child), 0)
+}
+
+interface LayoutNode {
+  node: TreeNode
+  x: number
+  y: number
+  isRoot: boolean
+}
+
+function computeLayout(tree: TreeNode): LayoutNode[] {
+  const result: LayoutNode[] = []
+
+  function layout(node: TreeNode, x: number, yStart: number, isRoot: boolean): void {
+    const h = getSubtreeHeight(node)
+    const cy = yStart + h / 2
+    result.push({ node, x, y: cy, isRoot })
+
+    if (node.children.length > 0) {
+      const childX = x + (isRoot ? ROOT_W : CHILD_DIAMETER) + GAP_X
+      let childYStart = yStart
+      for (const child of node.children) {
+        layout(child, childX, childYStart, false)
+        childYStart += getSubtreeHeight(child)
+      }
+    }
+  }
+
+  layout(tree, 0, 0, true)
+  return result
+}
 
 export default function OrgChart({ onSelectAgent }: OrgChartProps) {
   const [agents, setAgents] = useState<AgentInfo[]>([])
@@ -87,19 +170,20 @@ export default function OrgChart({ onSelectAgent }: OrgChartProps) {
     )
   }
 
-  const root = findRoot(agents)!
-  const children = agents.filter(a => a.id !== root.id)
+  const tree = buildTree(agents)
 
-  // --- Mobile vertical layout (< md) ---
-  // --- Desktop horizontal layout (>= md) ---
+  if (!tree) {
+    return (
+      <EmptyState icon="◎" title="No agents found" description="No active agent sessions" />
+    )
+  }
 
   return (
     <div ref={containerRef}>
       {/* Mobile: vertical stack */}
       <div className="flex flex-col gap-3 md:hidden">
         <MobileTree
-          root={root}
-          children={children}
+          tree={tree}
           selectedId={selectedId}
           onSelect={handleSelect}
         />
@@ -108,8 +192,7 @@ export default function OrgChart({ onSelectAgent }: OrgChartProps) {
       {/* Desktop: horizontal tree */}
       <div className="hidden md:block">
         <DesktopTree
-          root={root}
-          children={children}
+          tree={tree}
           selectedId={selectedId}
           onSelect={handleSelect}
         />
@@ -121,105 +204,73 @@ export default function OrgChart({ onSelectAgent }: OrgChartProps) {
 /* ── Desktop horizontal layout ─────────────────────────────────── */
 
 function DesktopTree({
-  root,
-  children,
+  tree,
   selectedId,
   onSelect,
 }: {
-  root: AgentInfo
-  children: AgentInfo[]
+  tree: TreeNode
   selectedId: string | null
   onSelect: (a: AgentInfo) => void
 }) {
-  const childCount = children.length
-  const treeH = Math.max(ROOT_H, childCount * CHILD_ROW_H)
-  const rootY = treeH / 2
-  const childStartX = ROOT_W + GAP_X
-  const svgH = treeH + 16
+  const layout = computeLayout(tree)
+
+  const totalW = Math.max(...layout.map(l => l.x + (l.isRoot ? ROOT_W : CHILD_DIAMETER))) + 100
+  const totalH = Math.max(...layout.map(l => l.y + (l.isRoot ? ROOT_H / 2 : CHILD_R))) + 20
+
+  function drawLines(node: TreeNode, parentLayout?: LayoutNode): React.ReactNode[] {
+    const lines: React.ReactNode[] = []
+    const myLayout = layout.find(l => l.node === node)!
+
+    if (parentLayout) {
+      const pRightX = parentLayout.x + (parentLayout.isRoot ? ROOT_W : CHILD_DIAMETER)
+      const midX = pRightX + GAP_X / 2
+      const isActive = node.agent.status === 'active'
+      const stroke = isActive ? '#22C55E' : '#403E3C'
+      const strokeW = isActive ? 1.5 : 1
+      lines.push(
+        <g key={`line-${node.agent.id}`}>
+          <line x1={pRightX} y1={parentLayout.y} x2={midX} y2={parentLayout.y} stroke={stroke} strokeWidth={strokeW} />
+          <line x1={midX} y1={parentLayout.y} x2={midX} y2={myLayout.y} stroke={stroke} strokeWidth={strokeW} />
+          <line x1={midX} y1={myLayout.y} x2={myLayout.x - CHILD_R - 4} y2={myLayout.y} stroke={stroke} strokeWidth={strokeW} />
+          <polygon points={arrowHead(myLayout.x - CHILD_R - 4, myLayout.y, 'right')} fill={stroke} />
+        </g>
+      )
+    }
+
+    for (const child of node.children) {
+      lines.push(...drawLines(child, myLayout))
+    }
+    return lines
+  }
 
   return (
-    <div className="relative" style={{ minHeight: svgH }}>
-      {/* SVG connections */}
+    <div className="relative" style={{ width: totalW, height: totalH }}>
       <svg
         className="absolute inset-0 pointer-events-none"
-        width="100%"
-        height={svgH}
+        width={totalW}
+        height={totalH}
         style={{ overflow: 'visible' }}
       >
-        {children.map((child, i) => {
-          const cy = (i + 0.5) * CHILD_ROW_H + 8
-          const isActive = child.status === 'active'
-          const stroke = isActive ? '#22C55E' : '#403E3C'
-          const strokeW = isActive ? 1.5 : 1
-          const midX = ROOT_W + GAP_X / 2
-
-          return (
-            <g key={child.id}>
-              {/* Horizontal from root → mid */}
-              <line
-                x1={ROOT_W}
-                y1={rootY}
-                x2={midX}
-                y2={rootY}
-                stroke={stroke}
-                strokeWidth={strokeW}
-              />
-              {/* Vertical from mid → child row */}
-              <line
-                x1={midX}
-                y1={rootY}
-                x2={midX}
-                y2={cy}
-                stroke={stroke}
-                strokeWidth={strokeW}
-              />
-              {/* Horizontal from mid → child */}
-              <line
-                x1={midX}
-                y1={cy}
-                x2={childStartX - CHILD_R - 4}
-                y2={cy}
-                stroke={stroke}
-                strokeWidth={strokeW}
-              />
-              {/* Arrow head */}
-              <polygon
-                points={arrowHead(childStartX - CHILD_R - 4, cy, 'right')}
-                fill={stroke}
-              />
-            </g>
-          )
-        })}
+        {drawLines(tree)}
       </svg>
 
-      {/* Root node */}
-      <div className="absolute" style={{ top: rootY - ROOT_H / 2, left: 0 }}>
-        <OrgNode
-          agent={root}
-          isRoot
-          isSelected={selectedId === root.id}
-          onClick={() => onSelect(root)}
-        />
-      </div>
-
-      {/* Child nodes */}
-      {children.map((child, i) => {
-        const cy = (i + 0.5) * CHILD_ROW_H + 8
-        return (
-          <div
-            key={child.id}
-            className="absolute"
-            style={{ top: cy - CHILD_R, left: childStartX - CHILD_R }}
-          >
-            <OrgNode
-              agent={child}
-              isRoot={false}
-              isSelected={selectedId === child.id}
-              onClick={() => onSelect(child)}
-            />
-          </div>
-        )
-      })}
+      {layout.map(({ node, x, y, isRoot }) => (
+        <div
+          key={node.agent.id}
+          className="absolute"
+          style={{
+            left: x,
+            top: y - (isRoot ? ROOT_H / 2 : CHILD_R),
+          }}
+        >
+          <OrgNode
+            agent={node.agent}
+            isRoot={isRoot}
+            isSelected={selectedId === node.agent.id}
+            onClick={() => onSelect(node.agent)}
+          />
+        </div>
+      ))}
     </div>
   )
 }
@@ -227,76 +278,73 @@ function DesktopTree({
 /* ── Mobile vertical layout ────────────────────────────────────── */
 
 function MobileTree({
-  root,
-  children,
+  tree,
   selectedId,
   onSelect,
 }: {
-  root: AgentInfo
-  children: AgentInfo[]
+  tree: TreeNode
   selectedId: string | null
   onSelect: (a: AgentInfo) => void
 }) {
+  return <MobileTreeNode node={tree} selectedId={selectedId} onSelect={onSelect} depth={0} />
+}
+
+function MobileTreeNode({
+  node,
+  selectedId,
+  onSelect,
+  depth,
+}: {
+  node: TreeNode
+  selectedId: string | null
+  onSelect: (a: AgentInfo) => void
+  depth: number
+}) {
+  const isActive = node.agent.status === 'active'
+  const stroke = isActive ? '#22C55E' : '#403E3C'
+  const strokeW = isActive ? 1.5 : 1
+
   return (
-    <>
-      <OrgNode
-        agent={root}
-        isRoot
-        isSelected={selectedId === root.id}
-        onClick={() => onSelect(root)}
-      />
-      <div className="relative ml-6 flex flex-col gap-2">
-        {/* Vertical line */}
+    <div className={depth > 0 ? 'relative pl-6' : ''}>
+      {depth > 0 && (
         <svg
-          className="absolute left-0 top-0 pointer-events-none"
+          className="absolute left-0 top-1/2 pointer-events-none"
           width="24"
-          height="100%"
-          style={{ overflow: 'visible' }}
+          height="2"
+          style={{ overflow: 'visible', transform: 'translateY(-50%)' }}
         >
-          <line
-            x1={0}
-            y1={0}
-            x2={0}
-            y2="100%"
-            stroke="#403E3C"
-            strokeWidth={1}
-          />
+          <line x1={0} y1={1} x2={20} y2={1} stroke={stroke} strokeWidth={strokeW} />
+          <polygon points={arrowHead(20, 1, 'right')} fill={stroke} />
         </svg>
-        {children.map(child => {
-          const isActive = child.status === 'active'
-          return (
-            <div key={child.id} className="relative pl-6">
-              {/* Horizontal tick */}
-              <svg
-                className="absolute left-0 top-1/2 pointer-events-none"
-                width="24"
-                height="2"
-                style={{ overflow: 'visible', transform: 'translateY(-50%)' }}
-              >
-                <line
-                  x1={0}
-                  y1={1}
-                  x2={20}
-                  y2={1}
-                  stroke={isActive ? '#22C55E' : '#403E3C'}
-                  strokeWidth={isActive ? 1.5 : 1}
-                />
-                <polygon
-                  points={arrowHead(20, 1, 'right')}
-                  fill={isActive ? '#22C55E' : '#403E3C'}
-                />
-              </svg>
-              <OrgNode
-                agent={child}
-                isRoot={false}
-                isSelected={selectedId === child.id}
-                onClick={() => onSelect(child)}
-              />
-            </div>
-          )
-        })}
-      </div>
-    </>
+      )}
+      <OrgNode
+        agent={node.agent}
+        isRoot={depth === 0}
+        isSelected={selectedId === node.agent.id}
+        onClick={() => onSelect(node.agent)}
+      />
+      {node.children.length > 0 && (
+        <div className="relative ml-6 flex flex-col gap-2">
+          <svg
+            className="absolute left-0 top-0 pointer-events-none"
+            width="24"
+            height="100%"
+            style={{ overflow: 'visible' }}
+          >
+            <line x1={0} y1={0} x2={0} y2="100%" stroke="#403E3C" strokeWidth={1} />
+          </svg>
+          {node.children.map(child => (
+            <MobileTreeNode
+              key={child.agent.id}
+              node={child}
+              selectedId={selectedId}
+              onSelect={onSelect}
+              depth={depth + 1}
+            />
+          ))}
+        </div>
+      )}
+    </div>
   )
 }
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -202,6 +202,7 @@ export interface AgentInfo {
   workspace_path: string | null;
   topic_id: number | null;
   model: string | null;
+  skills: string[];
   heartbeat_raw: Record<string, unknown> | null;
   mailbox: { inbox: number; processing: number; done: number; deadletter: number };
 }


### PR DESCRIPTION
## 3 Dashboard Fixes

### 1. Skills not showing in agent list
`server/api/agents.js` — GET / now reads `~/.openclaw/openclaw.json`, maps agent ids (sokrat→main), adds `skills[]` and `model` from config to each agent response.

### 2. Pipeline endpoint  
New `server/api/pipeline.js` — GET /api/pipeline parses `~/clawd/memory/tasks/TODO.md` (sections → status zones, checkboxes → items) + reads `~/clawd/tasks/active/*.yaml`. Registered before static middleware.

### 3. OrgChart hierarchy
`OrgChart.tsx` — HIERARCHY map defines real tree: Сократ→{Аристотель, Геродот, Brainstorm×2, Платон→Лео, Гефест→Архимед}. Recursive buildTree + orphan fallback for unknown agents. Desktop SVG elbow connectors + mobile indented list.

## Verification
- tsc: 0 errors ✅
- vite build: clean ✅  
- Tests: 102/102 passing ✅
- AgentInfo interface updated with `skills: string[]`

Closes #TBD