### PR TITLE
fix: visual review — toast spam, pipeline owner/dupes/mobile, OrgChart spacing (#93-#97)

### DIFF
--- a/server/api/pipeline.js
+++ b/server/api/pipeline.js
@@ -55,7 +55,7 @@ function parseTodo(raw) {
     const id = `todo_${String(counter).padStart(3, '0')}`
     counter++
 
-    items.push({ id, title, description, status, checkbox, section: currentSection })
+    items.push({ id, title, description, status, checkbox, section: currentSection, owner: 'unassigned' })
   }
 
   return items

--- a/src/components/agents/AgentDetail.tsx
+++ b/src/components/agents/AgentDetail.tsx
@@ -121,7 +121,7 @@ export default function AgentDetail({ agent, onClose, onToast }: AgentDetailProp
             <MailboxViewer agentId={agent.id} onToast={onToast} />
           )}
           {tab === 'Skills' && (
-            <SkillsManager agentId={agent.id} onToast={onToast} />
+            <SkillsManager agentId={agent.id} initialSkills={agent.skills ?? []} onToast={onToast} />
           )}
           {tab === 'INBOX.md' && (
             <InboxMdTab agentId={agent.id} />

--- a/src/components/agents/AgentDetailPanel.tsx
+++ b/src/components/agents/AgentDetailPanel.tsx
@@ -100,7 +100,7 @@ export default function AgentDetailPanel({ agent, onClose, onToast }: AgentDetai
 
       {/* Tab content */}
       <div className="p-4 min-h-[200px]">
-        {tab === 'Skills' && <SkillsManager agentId={agent.id} onToast={onToast} />}
+        {tab === 'Skills' && <SkillsManager agentId={agent.id} initialSkills={agent.skills ?? []} onToast={onToast} />}
         {tab === 'Files' && <FilesTab agentId={agent.id} onToast={onToast} />}
         {tab === 'Model' && <ModelSelector agent={agent} currentModel={agent.model ?? ''} onToast={onToast} />}
       </div>

--- a/src/components/agents/OrgChart.tsx
+++ b/src/components/agents/OrgChart.tsx
@@ -70,8 +70,8 @@ const ROOT_W = 80
 const ROOT_H = 100
 const CHILD_DIAMETER = 48
 const CHILD_R = CHILD_DIAMETER / 2
-const CHILD_ROW_H = 64
-const GAP_X = 60
+const CHILD_ROW_H = 80
+const GAP_X = 80
 
 function getSubtreeHeight(node: TreeNode): number {
   if (node.children.length === 0) return CHILD_ROW_H

--- a/src/components/agents/SkillsManager.tsx
+++ b/src/components/agents/SkillsManager.tsx
@@ -1,36 +1,35 @@
-import { useState, useEffect, useMemo, useCallback } from 'react'
-import { fetchAgentSkills, updateAgentSkills, fetchAllSkills } from '../../lib/api'
+import { useState, useEffect, useMemo, useCallback, useRef } from 'react'
+import { updateAgentSkills, fetchAllSkills } from '../../lib/api'
 import type { SkillsData } from '../../lib/api'
 import type { ToastPayload } from '../../hooks/useToast'
 
 interface SkillsManagerProps {
   agentId: string
+  initialSkills: string[]
   onToast: (toast: ToastPayload) => void
 }
 
-export default function SkillsManager({ agentId, onToast }: SkillsManagerProps) {
+export default function SkillsManager({ agentId, initialSkills, onToast }: SkillsManagerProps) {
+  const toastRef = useRef(onToast)
+  toastRef.current = onToast
+
   const [allSkills, setAllSkills] = useState<SkillsData | null>(null)
-  const [activeSkills, setActiveSkills] = useState<string[] | null>(null)
-  const [pendingSkills, setPendingSkills] = useState<Set<string> | null>(null)
+  const [activeSkills, setActiveSkills] = useState<string[]>(initialSkills)
+  const [pendingSkills, setPendingSkills] = useState<Set<string>>(new Set(initialSkills))
   const [loading, setLoading] = useState(true)
   const [applying, setApplying] = useState(false)
   const [dropdownOpen, setDropdownOpen] = useState(false)
 
   const load = useCallback(async () => {
     try {
-      const [skillsData, agentData] = await Promise.all([
-        fetchAllSkills(),
-        fetchAgentSkills(agentId),
-      ])
+      const skillsData = await fetchAllSkills()
       setAllSkills(skillsData)
-      setActiveSkills(agentData.skills)
-      setPendingSkills(new Set(agentData.skills))
     } catch {
-      onToast({ message: 'Failed to load skills', variant: 'error' })
+      toastRef.current({ message: 'Failed to load skills', variant: 'error' })
     } finally {
       setLoading(false)
     }
-  }, [agentId, onToast])
+  }, [agentId])
 
   useEffect(() => { load() }, [load])
 
@@ -48,13 +47,12 @@ export default function SkillsManager({ agentId, onToast }: SkillsManagerProps) 
 
   // Skills currently toggled on in the pending set
   const pendingArray = useMemo(
-    () => (pendingSkills ? [...pendingSkills].sort() : []),
+    () => [...pendingSkills].sort(),
     [pendingSkills],
   )
 
   // Compute changes from original
   const changes = useMemo(() => {
-    if (!activeSkills || !pendingSkills) return { added: [] as string[], removed: [] as string[] }
     const activeSet = new Set(activeSkills)
     const added = pendingArray.filter(s => !activeSet.has(s))
     const removed = activeSkills.filter(s => !pendingSkills.has(s))
@@ -65,13 +63,11 @@ export default function SkillsManager({ agentId, onToast }: SkillsManagerProps) 
 
   // Skills not currently in pending set (for the Add dropdown)
   const unassignedSkills = useMemo(() => {
-    if (!pendingSkills) return []
     return allSkillNames.filter(s => !pendingSkills.has(s))
   }, [allSkillNames, pendingSkills])
 
   const toggleSkill = (name: string) => {
     setPendingSkills(prev => {
-      if (!prev) return prev
       const next = new Set(prev)
       if (next.has(name)) {
         // Don't allow removing the last skill
@@ -86,7 +82,6 @@ export default function SkillsManager({ agentId, onToast }: SkillsManagerProps) 
 
   const addSkill = (name: string) => {
     setPendingSkills(prev => {
-      if (!prev) return prev
       const next = new Set(prev)
       next.add(name)
       return next
@@ -95,7 +90,6 @@ export default function SkillsManager({ agentId, onToast }: SkillsManagerProps) 
   }
 
   const handleApply = async () => {
-    if (!pendingSkills) return
     setApplying(true)
     try {
       const result = await updateAgentSkills(agentId, [...pendingSkills])
@@ -114,17 +108,11 @@ export default function SkillsManager({ agentId, onToast }: SkillsManagerProps) 
   }
 
   const handleDiscard = () => {
-    if (activeSkills) {
-      setPendingSkills(new Set(activeSkills))
-    }
+    setPendingSkills(new Set(activeSkills))
   }
 
   if (loading) {
     return <div className="text-[11px] text-text-tertiary py-4 text-center">Loading skills...</div>
-  }
-
-  if (!pendingSkills || !activeSkills) {
-    return <div className="text-[12px] text-text-tertiary py-8 text-center">Could not load skills</div>
   }
 
   return (

--- a/src/hooks/useToast.tsx
+++ b/src/hooks/useToast.tsx
@@ -55,6 +55,8 @@ export function ToastProvider({ children }: { children: ReactNode }) {
       : messageOrToast
     const toast: Toast = { id, dismissible: true, ...payload }
     setToasts((prev) => {
+      const last = prev[prev.length - 1]
+      if (last && last.message === toast.message && last.variant === toast.variant) return prev
       const next = [...prev, toast]
       if (next.length > MAX_TOASTS) {
         const removed = next.shift()!

--- a/src/pages/Pipeline.tsx
+++ b/src/pages/Pipeline.tsx
@@ -28,7 +28,9 @@ function PipelineCard({ item }: { item: PipelineItem }) {
       {item.description && <div className="text-xs text-text-secondary mt-1">{item.description}</div>}
       <div className="flex items-center gap-2 mt-2">
         <span className={`px-1.5 py-0.5 rounded text-[10px] font-mono ${badgeColor}`}>{item.status}</span>
-        {item.owner && <span className="text-[10px] text-text-tertiary font-mono">{item.owner}</span>}
+        <span className={`text-[10px] font-mono ${item.owner === "unassigned" ? "text-text-disabled" : "text-text-tertiary"}`}>
+          {item.owner ?? "unassigned"}
+        </span>
         {item.source === 'task-store' && <span className="text-[10px] text-text-disabled">task-store</span>}
       </div>
     </div>
@@ -38,10 +40,10 @@ function PipelineCard({ item }: { item: PipelineItem }) {
 // ─── Columns ──────────────────────────────────────────────────────────────────
 
 const COLUMNS = [
-  { key: 'blocked', label: '🔴 Blocked', filter: (i: PipelineItem) => i.section === 'blocked' || i.status === 'blocked' },
-  { key: 'in_progress', label: '🟡 In Progress', filter: (i: PipelineItem) => i.section === 'in_progress' && i.status !== 'completed' },
-  { key: 'open_questions', label: '❓ Open Questions', filter: (i: PipelineItem) => i.section === 'open_questions' },
-  { key: 'done', label: '✅ Done', filter: (i: PipelineItem) => i.section === 'done' || i.status === 'completed' },
+  { key: 'blocked', label: '🔴 Blocked', filter: (i: PipelineItem) => i.status === 'blocked' },
+  { key: 'in_progress', label: '🟡 In Progress', filter: (i: PipelineItem) => i.status !== 'blocked' && i.status !== 'completed' && (i.section === 'in_progress' || i.section === 'open') },
+  { key: 'open_questions', label: '❓ Open Questions', filter: (i: PipelineItem) => i.status !== 'blocked' && i.status !== 'completed' && i.section === 'open_questions' },
+  { key: 'done', label: '✅ Done', filter: (i: PipelineItem) => i.status === 'completed' },
 ] as const
 
 // ─── Pipeline Page ────────────────────────────────────────────────────────────
@@ -80,11 +82,11 @@ export default function Pipeline() {
       </div>
       {/* Columns */}
       <div className="flex-1 overflow-auto p-6">
-        <div className="grid grid-cols-4 gap-4 h-full">
+        <div className="flex gap-4 overflow-x-auto pb-2 sm:grid sm:grid-cols-4 h-full">
           {visibleColumns.map(col => {
             const colItems = items.filter(col.filter)
             return (
-              <div key={col.key} className="flex flex-col gap-2">
+              <div key={col.key} className="flex flex-col gap-2 min-w-[200px] flex-shrink-0 sm:min-w-0 sm:flex-shrink">
                 <div className="text-sm font-semibold text-text-secondary mb-2">
                   {col.label} <span className="text-text-disabled font-normal">({colItems.length})</span>
                 </div>

--- a/tests/client/agent-detail-panel.test.tsx
+++ b/tests/client/agent-detail-panel.test.tsx
@@ -18,12 +18,13 @@ const mockAgent: AgentInfo = {
   workspace_path: '/home/test/.openclaw/workspace-archimedes',
   topic_id: null,
   model: 'opus-4-6',
+  skills: ['core', 'code-review'],
   heartbeat_raw: null,
   mailbox: { inbox: 2, processing: 1, done: 5, deadletter: 0 },
 }
 
 // Mock SkillsManager and ModelSelector
-vi.mock('../../src/components/agents/SkillsManager', () => ({ default: () => <div data-testid="skills-manager-mock">SkillsManager</div> }))
+vi.mock('../../src/components/agents/SkillsManager', () => ({ default: ({ initialSkills }: { initialSkills: string[] }) => <div data-testid="skills-manager-mock" data-initial-skills={initialSkills.join(',')}>SkillsManager</div> }))
 vi.mock('../../src/components/agents/ModelSelector', () => ({ default: () => <div data-testid="model-selector-mock">ModelSelector</div> }))
 
 // Mock the API module

--- a/tests/client/pipeline-page.test.tsx
+++ b/tests/client/pipeline-page.test.tsx
@@ -63,6 +63,31 @@ describe('Pipeline page', () => {
     expect(screen.getByText(/Updated/)).toBeInTheDocument()
   })
 
+  it('item with section=in_progress + status=blocked appears only in Blocked column', () => {
+    vi.mocked(usePolling).mockReturnValue({
+      data: [
+        { id: 'x1', title: 'Ambiguous task', description: null, status: 'blocked', checkbox: '!', section: 'in_progress' },
+      ],
+      loading: false,
+      error: null,
+      refetch: vi.fn(),
+      refresh: vi.fn(),
+    })
+    render(<Pipeline />)
+
+    // Should appear exactly once across the whole page
+    const cards = screen.getAllByText('Ambiguous task')
+    expect(cards).toHaveLength(1)
+
+    // The Blocked column count should be (1)
+    const blockedHeader = screen.getByText(/🔴 Blocked/)
+    expect(blockedHeader.textContent).toContain('(1)')
+
+    // In Progress column count should be (0)
+    const inProgressHeader = screen.getByText(/🟡 In Progress/)
+    expect(inProgressHeader.textContent).toContain('(0)')
+  })
+
   it('hideEmpty toggle hides empty columns', () => {
     render(<Pipeline />)
 

--- a/tests/client/skills-manager.test.tsx
+++ b/tests/client/skills-manager.test.tsx
@@ -2,12 +2,10 @@ import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/re
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import SkillsManager from '../../src/components/agents/SkillsManager'
 
-const mockFetchAgentSkills = vi.fn()
 const mockUpdateAgentSkills = vi.fn()
 const mockFetchAllSkills = vi.fn()
 
 vi.mock('../../src/lib/api', () => ({
-  fetchAgentSkills: (...args: unknown[]) => mockFetchAgentSkills(...args),
   updateAgentSkills: (...args: unknown[]) => mockUpdateAgentSkills(...args),
   fetchAllSkills: (...args: unknown[]) => mockFetchAllSkills(...args),
 }))
@@ -28,7 +26,6 @@ describe('SkillsManager', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-    mockFetchAgentSkills.mockResolvedValue({ skills: [...AGENT_SKILLS] })
     mockFetchAllSkills.mockResolvedValue(ALL_SKILLS)
     mockUpdateAgentSkills.mockResolvedValue({ ok: true, skills: ['github', 'coding-agent'] })
   })
@@ -36,7 +33,7 @@ describe('SkillsManager', () => {
   afterEach(() => { cleanup() })
 
   it('renders correct toggle state from API', async () => {
-    render(<SkillsManager agentId="archimedes" onToast={onToast} />)
+    render(<SkillsManager agentId="archimedes" initialSkills={[...AGENT_SKILLS]} onToast={onToast} />)
     await waitFor(() => {
       expect(screen.getByText('github')).toBeTruthy()
     })
@@ -50,7 +47,7 @@ describe('SkillsManager', () => {
   })
 
   it('batch changes collected until Apply', async () => {
-    render(<SkillsManager agentId="archimedes" onToast={onToast} />)
+    render(<SkillsManager agentId="archimedes" initialSkills={[...AGENT_SKILLS]} onToast={onToast} />)
     await waitFor(() => {
       expect(screen.getByText('github')).toBeTruthy()
     })
@@ -74,7 +71,7 @@ describe('SkillsManager', () => {
   it('Apply sends PUT and shows confirmation toast', async () => {
     mockUpdateAgentSkills.mockResolvedValue({ ok: true, skills: ['coding-agent', 'github'] })
 
-    render(<SkillsManager agentId="archimedes" onToast={onToast} />)
+    render(<SkillsManager agentId="archimedes" initialSkills={[...AGENT_SKILLS]} onToast={onToast} />)
     await waitFor(() => {
       expect(screen.getByText('github')).toBeTruthy()
     })
@@ -104,7 +101,7 @@ describe('SkillsManager', () => {
   })
 
   it('Add Skill dropdown shows unassigned skills', async () => {
-    render(<SkillsManager agentId="archimedes" onToast={onToast} />)
+    render(<SkillsManager agentId="archimedes" initialSkills={[...AGENT_SKILLS]} onToast={onToast} />)
     await waitFor(() => {
       expect(screen.getByText('github')).toBeTruthy()
     })

--- a/tests/client/use-toast.test.tsx
+++ b/tests/client/use-toast.test.tsx
@@ -1,0 +1,45 @@
+import { renderHook, act } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import type { ReactNode } from 'react'
+import { ToastProvider, useToast } from '../../src/hooks/useToast'
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <ToastProvider>{children}</ToastProvider>
+}
+
+describe('useToast', () => {
+  it('deduplicates consecutive identical toasts', () => {
+    const { result } = renderHook(() => useToast(), { wrapper })
+
+    act(() => {
+      result.current.push({ message: 'Failed to load skills', variant: 'error' })
+      result.current.push({ message: 'Failed to load skills', variant: 'error' })
+      result.current.push({ message: 'Failed to load skills', variant: 'error' })
+    })
+
+    expect(result.current.toasts).toHaveLength(1)
+    expect(result.current.toasts[0].message).toBe('Failed to load skills')
+  })
+
+  it('allows distinct messages through', () => {
+    const { result } = renderHook(() => useToast(), { wrapper })
+
+    act(() => {
+      result.current.push({ message: 'Error A', variant: 'error' })
+      result.current.push({ message: 'Error B', variant: 'error' })
+    })
+
+    expect(result.current.toasts).toHaveLength(2)
+  })
+
+  it('allows same message with different variant', () => {
+    const { result } = renderHook(() => useToast(), { wrapper })
+
+    act(() => {
+      result.current.push({ message: 'Done', variant: 'success' })
+      result.current.push({ message: 'Done', variant: 'info' })
+    })
+
+    expect(result.current.toasts).toHaveLength(2)
+  })
+})


### PR DESCRIPTION
## Leo Visual Review Fixes

### 🔴 P0 Blockers

**#94 — Toast spam "Failed to load skills"**
- SkillsManager now takes `initialSkills` prop from agent data (no more `/api/agents/{id}/skills` 404)
- `onToast` wrapped in ref to break useCallback→useEffect re-render loop
- Toast dedup: `useToast.push` skips if last toast has same message+variant

**#93 — Pipeline cards missing owner**
- `parseTodo()` always sets `owner: "unassigned"`
- PipelineCard always renders owner (disabled style when unassigned)

### 🟡 Medium

**#95 — Duplicate cards across columns**
- Priority-based filtering: `status` overrides `section`
- `blocked` status → always Blocked column; `completed` → always Done

**#96 — Pipeline 390px cramped**
- Mobile: horizontal scroll with `min-w-[200px]` per column
- Desktop: `sm:grid sm:grid-cols-4`

**#97 — OrgChart node overlap**
- GAP_X: 60→80, CHILD_ROW_H: 64→80

### Tests
- Toast dedup test (new `use-toast.test.tsx`)
- Duplicate card prevention test
- Updated SkillsManager mock for `initialSkills` prop
- **125/125 passing ✅**

Closes #93, closes #94, closes #95, closes #96, closes #97