### PR TITLE
fix: restore full Kanban Pipeline from aa83aa5 (#99)

### DIFF
--- a/src/pages/Pipeline.tsx
+++ b/src/pages/Pipeline.tsx
@@ -1,7 +1,16 @@
-import { useState, useEffect } from 'react'
-import { fetchPipelineItems } from '../lib/api'
-import type { PipelineItem } from '../lib/api'
-import { usePolling } from '../hooks/usePolling'
+import { useState, useMemo, useCallback, useEffect } from 'react';
+import type { Task, PipelineState, StateGroup } from '../lib/types';
+import {
+  ERROR_STATES,
+  TERMINAL_STATES,
+  ACTIVE_STATES,
+  VALID_ROUTES,
+  VALID_OUTCOME_TYPES,
+} from '../lib/types';
+import { fetchTasks, createTask } from '../lib/api';
+import { usePolling } from '../hooks/usePolling';
+import { KanbanBoard } from '../components/pipeline/KanbanBoard';
+import { TaskDetail } from '../components/pipeline/TaskDetail';
 
 // ─── Freshness Indicator ──────────────────────────────────────────────────────
 
@@ -16,88 +25,302 @@ function Freshness({ ts }: { ts: number }) {
   return <span className="ml-3 text-[11px] font-mono text-text-disabled">Updated {label}</span>
 }
 
-// ─── Pipeline Card ────────────────────────────────────────────────────────────
+// ─── Filter Bar ───────────────────────────────────────────────────────────────
 
-function PipelineCard({ item }: { item: PipelineItem }) {
-  const badgeColor = item.status === 'blocked' ? 'bg-red/20 text-red'
-    : item.status === 'completed' ? 'bg-emerald/20 text-emerald'
-    : 'bg-amber/20 text-amber'
-  return (
-    <div className="p-3 bg-bg-surface border border-border-subtle rounded-md">
-      <div className="text-sm font-medium text-text-primary">{item.title}</div>
-      {item.description && <div className="text-xs text-text-secondary mt-1">{item.description}</div>}
-      <div className="flex items-center gap-2 mt-2">
-        <span className={`px-1.5 py-0.5 rounded text-[10px] font-mono ${badgeColor}`}>{item.status}</span>
-        <span className={`text-[10px] font-mono ${item.owner === "unassigned" ? "text-text-disabled" : "text-text-tertiary"}`}>
-          {item.owner ?? "unassigned"}
-        </span>
-        {item.source === 'task-store' && <span className="text-[10px] text-text-disabled">task-store</span>}
-      </div>
-    </div>
-  )
+interface Filters {
+  owners: string[];
+  route: string;
+  stateGroup: StateGroup;
 }
 
-// ─── Columns ──────────────────────────────────────────────────────────────────
+function FilterBar({
+  filters,
+  onChange,
+  allOwners,
+  onCreateClick,
+}: {
+  filters: Filters;
+  onChange: (f: Filters) => void;
+  allOwners: string[];
+  onCreateClick: () => void;
+}) {
+  return (
+    <div className="flex items-center gap-3 p-3 bg-bg-surface border-b border-border-subtle flex-wrap">
+      {/* Owner multi-select (simplified as select) */}
+      <select
+        value={filters.owners[0] || ''}
+        onChange={(e) =>
+          onChange({ ...filters, owners: e.target.value ? [e.target.value] : [] })
+        }
+        className="bg-bg-void border border-border-default rounded-sm px-2 py-1.5 text-sm font-mono text-text-primary focus:border-amber focus:outline-none"
+      >
+        <option value="">All owners</option>
+        {allOwners.map((o) => (
+          <option key={o} value={o}>{o}</option>
+        ))}
+      </select>
 
-const COLUMNS = [
-  { key: 'blocked', label: '🔴 Blocked', filter: (i: PipelineItem) => i.status === 'blocked' },
-  { key: 'in_progress', label: '🟡 In Progress', filter: (i: PipelineItem) => i.status !== 'blocked' && i.status !== 'completed' && (i.section === 'in_progress' || i.section === 'open') },
-  { key: 'open_questions', label: '❓ Open Questions', filter: (i: PipelineItem) => i.status !== 'blocked' && i.status !== 'completed' && i.section === 'open_questions' },
-  { key: 'done', label: '✅ Done', filter: (i: PipelineItem) => i.status === 'completed' },
-] as const
+      {/* Route filter */}
+      <select
+        value={filters.route}
+        onChange={(e) => onChange({ ...filters, route: e.target.value })}
+        className="bg-bg-void border border-border-default rounded-sm px-2 py-1.5 text-sm font-mono text-text-primary focus:border-amber focus:outline-none"
+      >
+        <option value="">All routes</option>
+        {VALID_ROUTES.map((r) => (
+          <option key={r} value={r}>{r.replace('_route', '')}</option>
+        ))}
+      </select>
+
+      {/* State group */}
+      <select
+        value={filters.stateGroup}
+        onChange={(e) =>
+          onChange({ ...filters, stateGroup: e.target.value as StateGroup })
+        }
+        className="bg-bg-void border border-border-default rounded-sm px-2 py-1.5 text-sm font-mono text-text-primary focus:border-amber focus:outline-none"
+      >
+        <option value="all">All states</option>
+        <option value="active">Active</option>
+        <option value="terminal">Terminal</option>
+        <option value="error">Error</option>
+      </select>
+
+      <div className="ml-auto">
+        <button
+          onClick={onCreateClick}
+          className="px-3 py-1.5 rounded-sm bg-amber text-text-inverse font-semibold text-sm hover:brightness-110 transition-all"
+        >
+          + Create Task
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ─── Create Task Modal ────────────────────────────────────────────────────────
+
+function CreateTaskModal({
+  onClose,
+  onCreated,
+}: {
+  onClose: () => void;
+  onCreated: () => void;
+}) {
+  const [title, setTitle] = useState('');
+  const [route, setRoute] = useState<string>('build_route');
+  const [outcomeType, setOutcomeType] = useState<string>('app_release');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!title.trim()) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await createTask({ title: title.trim(), route, outcome_type: outcomeType });
+      onCreated();
+      onClose();
+    } catch (err: unknown) {
+      const msg = (err as { message?: string }).message || 'Failed to create task';
+      setError(msg);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <>
+      <div className="fixed inset-0 bg-black/50 z-40" onClick={onClose} />
+      <div className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-50 w-[400px] bg-bg-elevated border border-border-subtle rounded-lg shadow-panel animate-fade-in">
+        <div className="flex items-center justify-between p-4 border-b border-border-subtle">
+          <h2 className="text-lg font-semibold text-text-primary">Create Task</h2>
+          <button onClick={onClose} className="text-text-secondary hover:text-text-primary">✕</button>
+        </div>
+        <form onSubmit={handleSubmit} className="p-4 space-y-4">
+          {error && (
+            <div className="p-2 rounded-md bg-red-subtle border border-red text-red text-xs font-mono">
+              {error}
+            </div>
+          )}
+
+          <div>
+            <label className="block text-sm text-text-secondary mb-1">Title *</label>
+            <input
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              className="w-full bg-bg-void border border-border-default rounded-sm px-3 py-2 text-sm font-mono text-text-primary focus:border-amber focus:outline-none"
+              placeholder="Task title..."
+              required
+              autoFocus
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm text-text-secondary mb-1">Route</label>
+            <select
+              value={route}
+              onChange={(e) => setRoute(e.target.value)}
+              className="w-full bg-bg-void border border-border-default rounded-sm px-2 py-2 text-sm font-mono text-text-primary focus:border-amber focus:outline-none"
+            >
+              {VALID_ROUTES.map((r) => (
+                <option key={r} value={r}>{r}</option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label className="block text-sm text-text-secondary mb-1">Outcome Type</label>
+            <select
+              value={outcomeType}
+              onChange={(e) => setOutcomeType(e.target.value)}
+              className="w-full bg-bg-void border border-border-default rounded-sm px-2 py-2 text-sm font-mono text-text-primary focus:border-amber focus:outline-none"
+            >
+              {VALID_OUTCOME_TYPES.map((o) => (
+                <option key={o} value={o}>{o}</option>
+              ))}
+            </select>
+          </div>
+
+          <div className="flex justify-end gap-2 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-3 py-1.5 rounded-sm border border-border-subtle text-text-secondary text-sm hover:bg-bg-elevated transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={!title.trim() || submitting}
+              className="px-4 py-1.5 rounded-sm bg-amber text-text-inverse font-semibold text-sm disabled:opacity-40 hover:brightness-110 transition-all"
+            >
+              {submitting ? 'Creating...' : 'Create'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </>
+  );
+}
 
 // ─── Pipeline Page ────────────────────────────────────────────────────────────
 
+function filterTasks(tasks: Task[], filters: Filters): Task[] {
+  return tasks.filter((t) => {
+    if (filters.owners.length > 0 && !filters.owners.includes(t.owner)) return false;
+    if (filters.route && t.route !== filters.route) return false;
+    if (filters.stateGroup === 'active' && !ACTIVE_STATES.includes(t.state)) return false;
+    if (filters.stateGroup === 'terminal' && !TERMINAL_STATES.includes(t.state as PipelineState))
+      return false;
+    if (filters.stateGroup === 'error' && !ERROR_STATES.includes(t.state as PipelineState))
+      return false;
+    return true;
+  });
+}
+
 export default function Pipeline() {
-  const { data: rawItems } = usePolling(fetchPipelineItems, 15000)
-  const items: PipelineItem[] = rawItems ?? []
-  const [hideEmpty, setHideEmpty] = useState(false)
-  const [lastUpdated, setLastUpdated] = useState<number>(Date.now())
+  const fetchTasksFn = useCallback(() => fetchTasks(), []);
+  const { data: tasks, loading, refresh } = usePolling(fetchTasksFn, 5000);
+  const [selectedTask, setSelectedTask] = useState<Task | null>(null);
+  const [showCreate, setShowCreate] = useState(false);
+  const [filters, setFilters] = useState<Filters>({
+    owners: [],
+    route: '',
+    stateGroup: 'all',
+  });
+  const [hideEmpty, setHideEmpty] = useState(false);
+  const [lastUpdated, setLastUpdated] = useState<number>(Date.now());
 
+  const allOwners = useMemo(() => {
+    if (!tasks) return [];
+    return [...new Set(tasks.map((t) => t.owner))].sort();
+  }, [tasks]);
+
+  const filteredTasks = useMemo(
+    () => filterTasks(tasks || [], filters),
+    [tasks, filters]
+  );
+
+  // Update freshness timestamp when tasks data changes
   useEffect(() => {
-    if (rawItems) setLastUpdated(Date.now())
-  }, [rawItems])
+    if (tasks) setLastUpdated(Date.now());
+  }, [tasks]);
 
-  const visibleColumns = hideEmpty
-    ? COLUMNS.filter(col => items.some(col.filter))
-    : COLUMNS
+  const handleCardClick = useCallback((task: Task) => {
+    setSelectedTask(task);
+  }, []);
+
+  const handleDetailClose = useCallback(() => {
+    setSelectedTask(null);
+  }, []);
+
+  const handleTransition = useCallback(() => {
+    setSelectedTask(null);
+    refresh();
+  }, [refresh]);
 
   return (
-    <div className="flex flex-col h-full">
-      {/* Header */}
-      <div className="flex items-center justify-between px-6 py-4 border-b border-border-subtle">
+    <div className="flex flex-col h-screen bg-bg-base">
+      {/* Top bar */}
+      <header className="h-[48px] flex items-center px-4 bg-bg-base border-b border-border-subtle shrink-0">
         <h1 className="text-lg font-semibold text-text-primary">Pipeline</h1>
-        <div className="flex items-center gap-4">
-          <label className="flex items-center gap-2 text-sm text-text-secondary cursor-pointer">
-            <input
-              type="checkbox"
-              checked={hideEmpty}
-              onChange={e => setHideEmpty(e.target.checked)}
-              className="rounded"
-            />
-            Hide empty
-          </label>
-          <Freshness ts={lastUpdated} />
-        </div>
+        {loading && !tasks && (
+          <span className="ml-3 text-text-tertiary text-sm">Loading...</span>
+        )}
+        {tasks && (
+          <span className="ml-3 text-text-tertiary font-mono text-xs">
+            {tasks.length} tasks
+          </span>
+        )}
+        <Freshness ts={lastUpdated} />
+        <label className="ml-auto flex items-center gap-1.5 cursor-pointer select-none">
+          <input
+            type="checkbox"
+            checked={hideEmpty}
+            onChange={(e) => setHideEmpty(e.target.checked)}
+            className="accent-amber w-3 h-3"
+          />
+          <span className="text-xs text-text-tertiary">Hide empty</span>
+        </label>
+      </header>
+
+      {/* Filter bar */}
+      <FilterBar
+        filters={filters}
+        onChange={setFilters}
+        allOwners={allOwners}
+        onCreateClick={() => setShowCreate(true)}
+      />
+
+      {/* Kanban board */}
+      <div className="flex-1 overflow-hidden">
+        <KanbanBoard
+          tasks={filteredTasks}
+          onCardClick={handleCardClick}
+          onRefresh={refresh}
+          hideEmpty={hideEmpty}
+        />
       </div>
-      {/* Columns */}
-      <div className="flex-1 overflow-auto p-6">
-        <div className="flex gap-4 overflow-x-auto pb-2 sm:grid sm:grid-cols-4 h-full">
-          {visibleColumns.map(col => {
-            const colItems = items.filter(col.filter)
-            return (
-              <div key={col.key} className="flex flex-col gap-2 min-w-[200px] flex-shrink-0 sm:min-w-0 sm:flex-shrink">
-                <div className="text-sm font-semibold text-text-secondary mb-2">
-                  {col.label} <span className="text-text-disabled font-normal">({colItems.length})</span>
-                </div>
-                {colItems.map(item => (
-                  <PipelineCard key={item.id} item={item} />
-                ))}
-              </div>
-            )
-          })}
-        </div>
-      </div>
+
+      {/* Task detail slide-in */}
+      {selectedTask && (
+        <TaskDetail
+          task={selectedTask}
+          onClose={handleDetailClose}
+          onTransition={handleTransition}
+        />
+      )}
+
+      {/* Create task modal */}
+      {showCreate && (
+        <CreateTaskModal
+          onClose={() => setShowCreate(false)}
+          onCreated={refresh}
+        />
+      )}
     </div>
-  )
+  );
 }

--- a/tests/client/pipeline-page.test.tsx
+++ b/tests/client/pipeline-page.test.tsx
@@ -1,12 +1,15 @@
 import { render, screen, fireEvent, cleanup } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { Task } from '../../src/lib/types'
 
-// Mock fetchPipelineItems from api
+// Mock api module
 vi.mock('../../src/lib/api', async () => {
   const actual = await vi.importActual('../../src/lib/api')
   return {
     ...actual,
-    fetchPipelineItems: vi.fn(),
+    fetchTasks: vi.fn(),
+    createTask: vi.fn(),
+    transitionTask: vi.fn(),
   }
 })
 
@@ -15,16 +18,63 @@ vi.mock('../../src/hooks/usePolling', () => ({
   usePolling: vi.fn(),
 }))
 
+// Mock KanbanBoard to avoid DnD complexity in unit tests
+vi.mock('../../src/components/pipeline/KanbanBoard', () => ({
+  KanbanBoard: ({ tasks, onCardClick, hideEmpty }: {
+    tasks: Task[];
+    onCardClick: (t: Task) => void;
+    onRefresh: () => void;
+    hideEmpty?: boolean;
+  }) => (
+    <div data-testid="kanban-board" data-hide-empty={hideEmpty}>
+      {tasks.map((t) => (
+        <div
+          key={t.id}
+          data-testid={`task-card-${t.id}`}
+          data-state={t.state}
+          data-owner={t.owner}
+          data-route={t.route}
+          onClick={() => onCardClick(t)}
+        >
+          {t.title}
+        </div>
+      ))}
+    </div>
+  ),
+}))
+
+// Mock TaskDetail
+vi.mock('../../src/components/pipeline/TaskDetail', () => ({
+  TaskDetail: ({ task, onClose }: { task: Task; onClose: () => void; onTransition: () => void }) => (
+    <div data-testid="task-detail">
+      <span data-testid="detail-title">{task.title}</span>
+      <button data-testid="detail-close" onClick={onClose}>Close</button>
+    </div>
+  ),
+}))
+
 import Pipeline from '../../src/pages/Pipeline'
 import { usePolling } from '../../src/hooks/usePolling'
 
-const mockItems = [
-  { id: '1', title: 'Blocked task', description: null, status: 'blocked', checkbox: '!', section: 'blocked' },
-  { id: '2', title: 'In progress task', description: 'doing it', status: 'pending', checkbox: ' ', section: 'in_progress' },
-  { id: '3', title: 'Done task', description: null, status: 'completed', checkbox: 'x', section: 'done' },
+const makeTasks: () => Task[] = () => [
+  {
+    id: 'tsk_001', state: 'EXECUTION', owner: 'sokrat', route: 'build_route',
+    title: 'Build dashboard', age: 10, ttl: null, blockers: 0, retries: 0,
+    terminal: false, hasQuality: false, hasOutcome: false, hasRelease: false,
+  },
+  {
+    id: 'tsk_002', state: 'DONE', owner: 'leo', route: 'artifact_route',
+    title: 'Design tokens', age: 120, ttl: null, blockers: 0, retries: 0,
+    terminal: true, hasQuality: true, hasOutcome: true, hasRelease: false,
+  },
+  {
+    id: 'tsk_003', state: 'BLOCKED', owner: 'sokrat', route: 'build_route',
+    title: 'Fix CI', age: 5, ttl: null, blockers: 1, retries: 2,
+    terminal: false, hasQuality: false, hasOutcome: false, hasRelease: false,
+  },
 ]
 
-describe('Pipeline page', () => {
+describe('Pipeline page (full Kanban)', () => {
   afterEach(() => {
     cleanup()
   })
@@ -32,7 +82,7 @@ describe('Pipeline page', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.mocked(usePolling).mockReturnValue({
-      data: mockItems,
+      data: makeTasks(),
       loading: false,
       error: null,
       refetch: vi.fn(),
@@ -40,70 +90,124 @@ describe('Pipeline page', () => {
     })
   })
 
-  it('renders pipeline columns', () => {
+  it('renders the Pipeline header and task count', () => {
     render(<Pipeline />)
-
-    expect(screen.getByText(/🔴 Blocked/)).toBeInTheDocument()
-    expect(screen.getByText(/🟡 In Progress/)).toBeInTheDocument()
-    expect(screen.getByText(/❓ Open Questions/)).toBeInTheDocument()
-    expect(screen.getByText(/✅ Done/)).toBeInTheDocument()
+    expect(screen.getByText('Pipeline')).toBeInTheDocument()
+    expect(screen.getByText('3 tasks')).toBeInTheDocument()
   })
 
-  it('shows items in correct columns', () => {
+  it('renders the KanbanBoard with all tasks', () => {
     render(<Pipeline />)
-
-    expect(screen.getByText('Blocked task')).toBeInTheDocument()
-    expect(screen.getByText('In progress task')).toBeInTheDocument()
-    expect(screen.getByText('Done task')).toBeInTheDocument()
+    expect(screen.getByTestId('kanban-board')).toBeInTheDocument()
+    expect(screen.getByText('Build dashboard')).toBeInTheDocument()
+    expect(screen.getByText('Design tokens')).toBeInTheDocument()
+    expect(screen.getByText('Fix CI')).toBeInTheDocument()
   })
 
-  it('shows freshness indicator', () => {
+  it('renders freshness indicator', () => {
     render(<Pipeline />)
-
     expect(screen.getByText(/Updated/)).toBeInTheDocument()
   })
 
-  it('item with section=in_progress + status=blocked appears only in Blocked column', () => {
+  it('renders FilterBar with owner, route, and state group selects', () => {
+    render(<Pipeline />)
+    // Owner select has "All owners" plus unique owners
+    const selects = screen.getAllByRole('combobox')
+    expect(selects.length).toBe(3) // owner, route, stateGroup
+  })
+
+  it('renders Create Task button', () => {
+    render(<Pipeline />)
+    expect(screen.getByText('+ Create Task')).toBeInTheDocument()
+  })
+
+  it('filters tasks by owner', () => {
+    render(<Pipeline />)
+    const ownerSelect = screen.getAllByRole('combobox')[0]
+
+    // Filter to 'leo' — should show only Design tokens
+    fireEvent.change(ownerSelect, { target: { value: 'leo' } })
+    expect(screen.getByText('Design tokens')).toBeInTheDocument()
+    expect(screen.queryByText('Build dashboard')).not.toBeInTheDocument()
+    expect(screen.queryByText('Fix CI')).not.toBeInTheDocument()
+  })
+
+  it('filters tasks by route', () => {
+    render(<Pipeline />)
+    const routeSelect = screen.getAllByRole('combobox')[1]
+
+    fireEvent.change(routeSelect, { target: { value: 'artifact_route' } })
+    expect(screen.getByText('Design tokens')).toBeInTheDocument()
+    expect(screen.queryByText('Build dashboard')).not.toBeInTheDocument()
+  })
+
+  it('filters tasks by stateGroup=active shows only active states', () => {
+    render(<Pipeline />)
+    const stateGroupSelect = screen.getAllByRole('combobox')[2]
+
+    fireEvent.change(stateGroupSelect, { target: { value: 'active' } })
+    // EXECUTION is active, DONE and BLOCKED are not
+    expect(screen.getByText('Build dashboard')).toBeInTheDocument()
+    expect(screen.queryByText('Design tokens')).not.toBeInTheDocument()
+    expect(screen.queryByText('Fix CI')).not.toBeInTheDocument()
+  })
+
+  it('filters tasks by stateGroup=error shows only error states', () => {
+    render(<Pipeline />)
+    const stateGroupSelect = screen.getAllByRole('combobox')[2]
+
+    fireEvent.change(stateGroupSelect, { target: { value: 'error' } })
+    expect(screen.getByText('Fix CI')).toBeInTheDocument()
+    expect(screen.queryByText('Build dashboard')).not.toBeInTheDocument()
+    expect(screen.queryByText('Design tokens')).not.toBeInTheDocument()
+  })
+
+  it('clicking a task card opens TaskDetail', () => {
+    render(<Pipeline />)
+    fireEvent.click(screen.getByText('Build dashboard'))
+    expect(screen.getByTestId('task-detail')).toBeInTheDocument()
+    expect(screen.getByTestId('detail-title')).toHaveTextContent('Build dashboard')
+  })
+
+  it('closing TaskDetail removes it', () => {
+    render(<Pipeline />)
+    fireEvent.click(screen.getByText('Build dashboard'))
+    expect(screen.getByTestId('task-detail')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('detail-close'))
+    expect(screen.queryByTestId('task-detail')).not.toBeInTheDocument()
+  })
+
+  it('clicking Create Task opens CreateTaskModal', () => {
+    render(<Pipeline />)
+    fireEvent.click(screen.getByText('+ Create Task'))
+    expect(screen.getByText('Create Task', { selector: 'h2' })).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('Task title...')).toBeInTheDocument()
+  })
+
+  it('hideEmpty checkbox passes prop to KanbanBoard', () => {
+    render(<Pipeline />)
+    const checkbox = screen.getByLabelText('Hide empty')
+    expect(screen.getByTestId('kanban-board')).toHaveAttribute('data-hide-empty', 'false')
+
+    fireEvent.click(checkbox)
+    expect(screen.getByTestId('kanban-board')).toHaveAttribute('data-hide-empty', 'true')
+  })
+
+  it('shows loading state when no data yet', () => {
     vi.mocked(usePolling).mockReturnValue({
-      data: [
-        { id: 'x1', title: 'Ambiguous task', description: null, status: 'blocked', checkbox: '!', section: 'in_progress' },
-      ],
-      loading: false,
+      data: null,
+      loading: true,
       error: null,
       refetch: vi.fn(),
       refresh: vi.fn(),
     })
     render(<Pipeline />)
-
-    // Should appear exactly once across the whole page
-    const cards = screen.getAllByText('Ambiguous task')
-    expect(cards).toHaveLength(1)
-
-    // The Blocked column count should be (1)
-    const blockedHeader = screen.getByText(/🔴 Blocked/)
-    expect(blockedHeader.textContent).toContain('(1)')
-
-    // In Progress column count should be (0)
-    const inProgressHeader = screen.getByText(/🟡 In Progress/)
-    expect(inProgressHeader.textContent).toContain('(0)')
+    expect(screen.getByText('Loading...')).toBeInTheDocument()
   })
 
-  it('hideEmpty toggle hides empty columns', () => {
+  it('usePolling is called with fetchTasks and 5000ms interval', () => {
     render(<Pipeline />)
-
-    // Before toggling: Open Questions column should be present (no items, but visible)
-    expect(screen.getByText(/❓ Open Questions/)).toBeInTheDocument()
-
-    // Check the "Hide empty" checkbox
-    const checkbox = screen.getByRole('checkbox')
-    fireEvent.click(checkbox)
-
-    // Open Questions column has no items and should be hidden
-    expect(screen.queryByText(/❓ Open Questions/)).not.toBeInTheDocument()
-
-    // Columns with items should still be visible
-    expect(screen.getByText(/🔴 Blocked/)).toBeInTheDocument()
-    expect(screen.getByText(/🟡 In Progress/)).toBeInTheDocument()
-    expect(screen.getByText(/✅ Done/)).toBeInTheDocument()
+    expect(usePolling).toHaveBeenCalledWith(expect.any(Function), 5000)
   })
 })


### PR DESCRIPTION
## Summary
- Restored `Pipeline.tsx` from commit aa83aa5 with full Kanban: KanbanBoard (18 state columns + DnD), FilterBar (owner/route/stateGroup), TaskDetail panel, CreateTaskModal, and `usePolling(fetchTasks, 5000)` for live updates
- Data now sourced from `/api/tasks` (normalized via `fetchTasks()`) instead of `/api/pipeline`
- Rewrote `pipeline-page.test.tsx` with 15 tests covering: KanbanBoard rendering, all three filter types, TaskDetail open/close, CreateTaskModal, hideEmpty toggle, loading state, and polling interval

Closes #99

## Test plan
- [x] All 135 tests pass (20 test files, 0 regressions)
- [x] TypeScript compiles cleanly
- [x] ESLint passes on Pipeline.tsx
- [x] KanbanBoard receives filtered tasks with correct props
- [x] FilterBar: owner, route, stateGroup filters narrow visible tasks
- [x] TaskDetail opens on card click, closes on dismiss
- [x] Create Task button opens modal with title/route/outcome fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)