### PR TITLE
feat: FlowStrip — agent chain on task cards (#66)

### DIFF
--- a/src/components/pipeline/FlowStrip.tsx
+++ b/src/components/pipeline/FlowStrip.tsx
@@ -8,7 +8,34 @@ const AGENT_EMOJI: Record<string, string> = {
   'hephaestus':        '⚒️',
   'brainstorm-claude': '🧠',
   'brainstorm-codex':  '💡',
+  'code-review-gate':  '🛡️',
   'unknown':           '👤',
+};
+
+const AGENT_ROLES: Record<string, string> = {
+  'sokrat':            'Orchestrator',
+  'archimedes':        'Engineer',
+  'platon':            'Architect',
+  'leo':               'Designer',
+  'aristotle':         'Analyst',
+  'herodotus':         'Historian',
+  'hephaestus':        'DevOps',
+  'brainstorm-claude': 'Brainstorm (Claude)',
+  'brainstorm-codex':  'Brainstorm (Codex)',
+  'code-review-gate':  'Code Review',
+};
+
+const AGENT_DISPLAY_NAMES: Record<string, string> = {
+  'sokrat':            'Сократ',
+  'archimedes':        'Архимед',
+  'platon':            'Платон',
+  'leo':               'Лео',
+  'aristotle':         'Аристотель',
+  'herodotus':         'Геродот',
+  'hephaestus':        'Гефест',
+  'brainstorm-claude': 'Brainstorm Claude',
+  'brainstorm-codex':  'Brainstorm Codex',
+  'code-review-gate':  'Code Review Gate',
 };
 
 function normalizeActor(actor: string): string {
@@ -19,6 +46,12 @@ function normalizeActor(actor: string): string {
 
 function getEmoji(actor: string): string {
   return AGENT_EMOJI[actor] ?? AGENT_EMOJI['unknown'];
+}
+
+function getTooltip(actor: string): string {
+  const name = AGENT_DISPLAY_NAMES[actor] ?? actor;
+  const role = AGENT_ROLES[actor];
+  return role ? `${name} — ${role}` : name;
 }
 
 interface FlowStripProps {
@@ -34,15 +67,17 @@ export default function FlowStrip({ actors, maxVisible = 5 }: FlowStripProps) {
   const visible = overflow > 0 ? normalized.slice(0, maxVisible - 1) : normalized;
 
   return (
-    <div className="flex items-center gap-0.5 mt-1.5 flex-wrap">
+    <div className="flex items-center gap-0.5 mt-1.5 flex-wrap max-sm:[&>span:nth-child(n+4)]:hidden" data-testid="flow-strip">
       {visible.map((actor, i) => (
         <span key={`${actor}-${i}`} className="flex items-center gap-0.5">
           {i > 0 && (
-            <span className="text-text-disabled text-[10px]">→</span>
+            <span className="text-text-disabled text-[10px]" aria-hidden="true">→</span>
           )}
           <span
-            title={actor}
+            title={getTooltip(actor)}
             className="inline-flex items-center justify-center w-5 h-5 rounded-full bg-bg-overlay border border-border-subtle text-xs"
+            role="img"
+            aria-label={getTooltip(actor)}
           >
             {getEmoji(actor)}
           </span>
@@ -50,10 +85,22 @@ export default function FlowStrip({ actors, maxVisible = 5 }: FlowStripProps) {
       ))}
       {overflow > 0 && (
         <span className="flex items-center gap-0.5">
-          <span className="text-text-disabled text-[10px]">→</span>
-          <span className="inline-flex items-center justify-center w-5 h-5 rounded-full bg-bg-overlay border border-border-subtle text-xs text-text-secondary font-mono">
+          <span className="text-text-disabled text-[10px]" aria-hidden="true">→</span>
+          <span
+            className="inline-flex items-center justify-center w-5 h-5 rounded-full bg-bg-overlay border border-border-subtle text-xs text-text-secondary font-mono"
+            title={`${overflow} more agent${overflow > 1 ? 's' : ''}`}
+          >
             +{overflow}
           </span>
+        </span>
+      )}
+      {/* Mobile overflow: show +N for hidden avatars (>3 on small screens) */}
+      {normalized.length > 3 && (
+        <span
+          className="hidden max-sm:inline-flex items-center justify-center w-5 h-5 rounded-full bg-bg-overlay border border-border-subtle text-xs text-text-secondary font-mono"
+          title={`${normalized.length - 3} more agent${normalized.length - 3 > 1 ? 's' : ''}`}
+        >
+          +{normalized.length - 3}
         </span>
       )}
     </div>

--- a/tests/client/flow-strip.test.tsx
+++ b/tests/client/flow-strip.test.tsx
@@ -1,0 +1,107 @@
+import { render, screen, cleanup } from '@testing-library/react'
+import { describe, it, expect, afterEach } from 'vitest'
+
+import FlowStrip from '../../src/components/pipeline/FlowStrip'
+
+describe('FlowStrip', () => {
+  afterEach(cleanup)
+
+  it('renders correct actors from event data', () => {
+    render(<FlowStrip actors={['sokrat', 'archimedes', 'leo']} />)
+    const strip = screen.getByTestId('flow-strip')
+    expect(strip).toBeInTheDocument()
+    // Check emojis are rendered
+    expect(strip.textContent).toContain('🦉')
+    expect(strip.textContent).toContain('⚙️')
+    expect(strip.textContent).toContain('🎨')
+    // Check arrows between actors
+    expect(strip.querySelectorAll('[aria-hidden="true"]').length).toBe(2)
+  })
+
+  it('normalizes "main" to sokrat', () => {
+    render(<FlowStrip actors={['main']} />)
+    const avatar = screen.getByRole('img')
+    expect(avatar).toHaveAttribute('title', 'Сократ — Orchestrator')
+    expect(avatar.textContent).toContain('🦉')
+  })
+
+  it('normalizes "brainstorm" to brainstorm-claude', () => {
+    render(<FlowStrip actors={['brainstorm']} />)
+    const avatar = screen.getByRole('img')
+    expect(avatar).toHaveAttribute('title', 'Brainstorm Claude — Brainstorm (Claude)')
+  })
+
+  it('shows tooltip with agent name and role', () => {
+    render(<FlowStrip actors={['archimedes']} />)
+    const avatar = screen.getByRole('img')
+    expect(avatar).toHaveAttribute('title', 'Архимед — Engineer')
+    expect(avatar).toHaveAttribute('aria-label', 'Архимед — Engineer')
+  })
+
+  it('shows unknown emoji for unrecognized actors', () => {
+    render(<FlowStrip actors={['mysterious-agent']} />)
+    const avatar = screen.getByRole('img')
+    expect(avatar.textContent).toContain('👤')
+    expect(avatar).toHaveAttribute('title', 'mysterious-agent')
+  })
+
+  it('shows overflow +N when more than 5 actors', () => {
+    const actors = ['sokrat', 'archimedes', 'platon', 'leo', 'aristotle', 'herodotus', 'hephaestus']
+    render(<FlowStrip actors={actors} />)
+    const strip = screen.getByTestId('flow-strip')
+    // 4 visible avatars + 1 overflow indicator = showing +3
+    expect(strip.textContent).toContain('+3')
+    // Should show exactly 4 agent emojis (maxVisible-1 = 4)
+    const avatars = screen.getAllByRole('img')
+    expect(avatars.length).toBe(4)
+  })
+
+  it('shows all avatars when exactly at max (no desktop overflow)', () => {
+    const actors = ['sokrat', 'archimedes', 'platon', 'leo', 'aristotle']
+    render(<FlowStrip actors={actors} />)
+    const avatars = screen.getAllByRole('img')
+    expect(avatars.length).toBe(5)
+    // No desktop overflow indicator (the +N with font-mono that's not hidden)
+    // Mobile overflow (+2) is present in DOM but hidden via CSS max-sm:
+    const strip = screen.getByTestId('flow-strip')
+    const overflowSpans = strip.querySelectorAll('.font-mono')
+    // Only the mobile overflow span should exist (hidden via CSS), not a desktop one
+    expect(overflowSpans.length).toBe(1)
+    expect(overflowSpans[0].classList.contains('hidden')).toBe(true)
+  })
+
+  it('respects custom maxVisible', () => {
+    const actors = ['sokrat', 'archimedes', 'platon', 'leo']
+    render(<FlowStrip actors={actors} maxVisible={3} />)
+    const avatars = screen.getAllByRole('img')
+    expect(avatars.length).toBe(2) // maxVisible-1 = 2
+    const strip = screen.getByTestId('flow-strip')
+    expect(strip.textContent).toContain('+2')
+  })
+
+  it('renders nothing for empty actors array', () => {
+    const { container } = render(<FlowStrip actors={[]} />)
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('renders nothing when actors is undefined-like', () => {
+    // @ts-expect-error testing runtime safety
+    const { container } = render(<FlowStrip actors={null} />)
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('includes code-review-gate agent', () => {
+    render(<FlowStrip actors={['code-review-gate']} />)
+    const avatar = screen.getByRole('img')
+    expect(avatar.textContent).toContain('🛡️')
+    expect(avatar).toHaveAttribute('title', 'Code Review Gate — Code Review')
+  })
+
+  it('preserves chronological order', () => {
+    render(<FlowStrip actors={['leo', 'sokrat', 'archimedes']} />)
+    const avatars = screen.getAllByRole('img')
+    expect(avatars[0].textContent).toContain('🎨') // leo first
+    expect(avatars[1].textContent).toContain('🦉') // sokrat second
+    expect(avatars[2].textContent).toContain('⚙️') // archimedes third
+  })
+})


### PR DESCRIPTION
## Summary
- Enhanced `FlowStrip` component with agent name + role tooltips on hover (e.g. "Архимед — Engineer")
- Added `code-review-gate` agent to the emoji/role mapping
- Mobile responsive: max 3 avatars on small screens (`max-sm:`) with `+N` overflow indicator
- Added `aria-label` and `role="img"` for accessibility
- Added 12 comprehensive tests covering rendering, overflow, empty state, actor normalization

## What was already in place
- FlowStrip component existed with basic emoji rendering and overflow
- Backend `extractActors()` already populates `actors` field from `events.ndjson`
- TaskCard already integrated FlowStrip in the correct position

## Acceptance Criteria
- [x] FlowStrip renders on every task card
- [x] Shows correct actors in chronological order
- [x] Max 5 avatars, `+N` for overflow
- [x] Tooltip shows agent name + role on hover
- [x] No layout shift on cards without events (returns null)
- [x] Mobile: avatars shrink to max 3 + `+N`

## Test plan
- [x] 12 tests pass in `tests/client/flow-strip.test.tsx`
- [x] All 96 existing tests still pass
- [x] ESLint clean
- [x] TypeScript clean

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)