### PR TITLE
feat(#67): comment system for AWAITING_OWNER tasks

### DIFF
--- a/src/components/pipeline/CommentInput.tsx
+++ b/src/components/pipeline/CommentInput.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback } from 'react';
 import { addTaskEvent } from '../../lib/api';
+import { useToast } from '../../hooks/useToast';
 
 interface CommentInputProps {
   taskId: string;
@@ -9,24 +10,23 @@ interface CommentInputProps {
 export function CommentInput({ taskId, onCommentAdded }: CommentInputProps) {
   const [text, setText] = useState('');
   const [sending, setSending] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const { push } = useToast();
 
   const send = useCallback(async () => {
     const body = text.trim();
     if (!body || sending) return;
     setSending(true);
-    setError(null);
     try {
       await addTaskEvent(taskId, 'USER_COMMENT', { actor: 'owner', body });
       setText('');
       onCommentAdded();
     } catch (e: unknown) {
       const err = e as { message?: string };
-      setError(err?.message || 'Failed to send comment');
+      push(err?.message || 'Failed to send comment', 'error');
     } finally {
       setSending(false);
     }
-  }, [taskId, text, sending, onCommentAdded]);
+  }, [taskId, text, sending, onCommentAdded, push]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
@@ -40,9 +40,6 @@ export function CommentInput({ taskId, onCommentAdded }: CommentInputProps) {
 
   return (
     <div className="flex flex-col gap-2">
-      {error && (
-        <p className="text-xs text-red font-mono">{error}</p>
-      )}
       <textarea
         rows={2}
         value={text}
@@ -52,11 +49,11 @@ export function CommentInput({ taskId, onCommentAdded }: CommentInputProps) {
         placeholder="Add a comment… (Ctrl+Enter to send)"
         className="w-full bg-bg-void border border-border-default rounded-sm px-2 py-1.5 text-sm text-text-primary placeholder:text-text-disabled focus:border-amber focus:outline-none resize-none disabled:opacity-50"
       />
-      <div className="flex justify-end">
+      <div className="flex justify-end max-sm:block">
         <button
           onClick={send}
           disabled={sending || !text.trim()}
-          className="px-3 py-1.5 rounded-sm bg-amber text-text-inverse font-semibold text-sm disabled:opacity-40 disabled:cursor-not-allowed hover:brightness-110 transition-all"
+          className="px-3 py-1.5 rounded-sm bg-amber text-text-inverse font-semibold text-sm disabled:opacity-40 disabled:cursor-not-allowed hover:brightness-110 transition-all max-sm:w-full"
         >
           {sending ? 'Sending…' : 'Send'}
         </button>

--- a/src/components/pipeline/CommentThread.tsx
+++ b/src/components/pipeline/CommentThread.tsx
@@ -45,7 +45,7 @@ export function CommentThread({ comments }: CommentThreadProps) {
   }
 
   return (
-    <div className="max-h-[300px] overflow-y-auto space-y-3">
+    <div className="max-h-[300px] overflow-y-auto space-y-3" data-testid="comment-thread">
       {comments.map((comment, i) => (
         <div key={i} className="flex gap-2 text-sm">
           <span className="flex-shrink-0 w-6 h-6 flex items-center justify-center rounded-full bg-bg-overlay border border-border-subtle text-xs">
@@ -54,7 +54,7 @@ export function CommentThread({ comments }: CommentThreadProps) {
           <div className="min-w-0 flex-1">
             <div className="flex items-baseline gap-1.5 flex-wrap">
               <span className="font-semibold text-text-primary">{comment.actor}</span>
-              <span className="text-xs text-text-tertiary">{relativeTime(comment.timestamp)}</span>
+              <span className="text-xs text-text-tertiary max-sm:text-[10px]">{relativeTime(comment.timestamp)}</span>
             </div>
             <p className="text-text-secondary mt-0.5 break-words">{comment.body}</p>
           </div>

--- a/src/components/pipeline/TaskDetail.tsx
+++ b/src/components/pipeline/TaskDetail.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback, useRef } from 'react';
 import type { Task, TaskEvent, TaskDecision, TaskContract } from '../../lib/types';
 import { PIPELINE_STATES } from '../../lib/types';
 import { fetchTaskEvents, fetchTaskDecisions, fetchTaskContract, transitionTask, addTaskEvent } from '../../lib/api';
@@ -19,6 +19,7 @@ export function TaskDetail({ task, onClose, onTransition }: TaskDetailProps) {
   const [loading, setLoading] = useState(true);
   const [transitionState, setTransitionState] = useState<import('../../lib/types').PipelineState | ''>('');
   const [actionError, setActionError] = useState<string | null>(null);
+  const commentSectionRef = useRef<HTMLElement>(null);
 
   useEffect(() => {
     setLoading(true);
@@ -33,6 +34,13 @@ export function TaskDetail({ task, onClose, onTransition }: TaskDetailProps) {
       setLoading(false);
     });
   }, [task.id]);
+
+  // Scroll to comments section when opening AWAITING_OWNER task
+  useEffect(() => {
+    if (!loading && task.state === 'AWAITING_OWNER' && commentSectionRef.current) {
+      commentSectionRef.current.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+  }, [loading, task.state]);
 
   // Close on Escape
   useEffect(() => {
@@ -157,7 +165,7 @@ export function TaskDetail({ task, onClose, onTransition }: TaskDetailProps) {
             </section>
 
             {/* Comments */}
-            <section>
+            <section ref={commentSectionRef}>
               <h3 className="text-sm font-semibold text-text-secondary uppercase tracking-wider mb-2">
                 Comments
               </h3>

--- a/tests/client/comment-system.test.tsx
+++ b/tests/client/comment-system.test.tsx
@@ -1,0 +1,150 @@
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
+
+// Mock useToast
+const mockPush = vi.fn()
+vi.mock('../../src/hooks/useToast', () => ({
+  useToast: () => ({ toasts: [], push: mockPush, dismiss: vi.fn(), dismissAll: vi.fn() }),
+}))
+
+// Mock api
+vi.mock('../../src/lib/api', () => ({
+  addTaskEvent: vi.fn(),
+}))
+
+import { CommentThread } from '../../src/components/pipeline/CommentThread'
+import { CommentInput } from '../../src/components/pipeline/CommentInput'
+import { addTaskEvent } from '../../src/lib/api'
+
+describe('CommentThread', () => {
+  afterEach(cleanup)
+
+  it('renders empty state when no comments', () => {
+    render(<CommentThread comments={[]} />)
+    expect(screen.getByText('No comments yet')).toBeInTheDocument()
+  })
+
+  it('renders comments in order with author and time', () => {
+    const comments = [
+      { actor: 'owner', body: 'First comment', timestamp: new Date(Date.now() - 120000).toISOString() },
+      { actor: 'archimedes', body: 'Second comment', timestamp: new Date(Date.now() - 60000).toISOString() },
+    ]
+    render(<CommentThread comments={comments} />)
+
+    expect(screen.getByText('First comment')).toBeInTheDocument()
+    expect(screen.getByText('Second comment')).toBeInTheDocument()
+    expect(screen.getByText('owner')).toBeInTheDocument()
+    expect(screen.getByText('archimedes')).toBeInTheDocument()
+  })
+
+  it('shows correct agent emojis', () => {
+    const comments = [
+      { actor: 'owner', body: 'Hello', timestamp: new Date().toISOString() },
+      { actor: 'archimedes', body: 'Hi', timestamp: new Date().toISOString() },
+    ]
+    render(<CommentThread comments={comments} />)
+    const thread = screen.getByTestId('comment-thread')
+    expect(thread.textContent).toContain('💬')
+    expect(thread.textContent).toContain('⚙️')
+  })
+
+  it('shows relative timestamps', () => {
+    const comments = [
+      { actor: 'owner', body: 'Just now', timestamp: new Date().toISOString() },
+      { actor: 'owner', body: 'Minutes ago', timestamp: new Date(Date.now() - 300000).toISOString() },
+    ]
+    render(<CommentThread comments={comments} />)
+    expect(screen.getByText('just now')).toBeInTheDocument()
+    expect(screen.getByText('5m ago')).toBeInTheDocument()
+  })
+
+  it('shows unknown emoji for unrecognized actors', () => {
+    const comments = [
+      { actor: 'mystery', body: 'Test', timestamp: new Date().toISOString() },
+    ]
+    render(<CommentThread comments={comments} />)
+    const thread = screen.getByTestId('comment-thread')
+    expect(thread.textContent).toContain('👤')
+  })
+})
+
+describe('CommentInput', () => {
+  afterEach(cleanup)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(addTaskEvent).mockResolvedValue({ ok: true })
+  })
+
+  it('renders textarea and send button', () => {
+    render(<CommentInput taskId="tsk_001" onCommentAdded={vi.fn()} />)
+    expect(screen.getByPlaceholderText(/add a comment/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /send/i })).toBeInTheDocument()
+  })
+
+  it('send button is disabled when textarea is empty', () => {
+    render(<CommentInput taskId="tsk_001" onCommentAdded={vi.fn()} />)
+    expect(screen.getByRole('button', { name: /send/i })).toBeDisabled()
+  })
+
+  it('sends USER_COMMENT event on click and clears textarea', async () => {
+    const onAdded = vi.fn()
+    render(<CommentInput taskId="tsk_001" onCommentAdded={onAdded} />)
+
+    const textarea = screen.getByPlaceholderText(/add a comment/i)
+    fireEvent.change(textarea, { target: { value: 'Test comment' } })
+    expect(screen.getByRole('button', { name: /send/i })).not.toBeDisabled()
+
+    fireEvent.click(screen.getByRole('button', { name: /send/i }))
+
+    await waitFor(() => {
+      expect(addTaskEvent).toHaveBeenCalledWith('tsk_001', 'USER_COMMENT', {
+        actor: 'owner',
+        body: 'Test comment',
+      })
+    })
+
+    await waitFor(() => {
+      expect(onAdded).toHaveBeenCalled()
+      expect(textarea).toHaveValue('')
+    })
+  })
+
+  it('sends on Ctrl+Enter', async () => {
+    const onAdded = vi.fn()
+    render(<CommentInput taskId="tsk_001" onCommentAdded={onAdded} />)
+
+    const textarea = screen.getByPlaceholderText(/add a comment/i)
+    fireEvent.change(textarea, { target: { value: 'Ctrl enter test' } })
+    fireEvent.keyDown(textarea, { key: 'Enter', ctrlKey: true })
+
+    await waitFor(() => {
+      expect(addTaskEvent).toHaveBeenCalledWith('tsk_001', 'USER_COMMENT', {
+        actor: 'owner',
+        body: 'Ctrl enter test',
+      })
+    })
+  })
+
+  it('shows toast on error', async () => {
+    vi.mocked(addTaskEvent).mockRejectedValue(new Error('Network error'))
+    render(<CommentInput taskId="tsk_001" onCommentAdded={vi.fn()} />)
+
+    const textarea = screen.getByPlaceholderText(/add a comment/i)
+    fireEvent.change(textarea, { target: { value: 'Will fail' } })
+    fireEvent.click(screen.getByRole('button', { name: /send/i }))
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith('Network error', 'error')
+    })
+  })
+
+  it('does not send whitespace-only messages', async () => {
+    render(<CommentInput taskId="tsk_001" onCommentAdded={vi.fn()} />)
+
+    const textarea = screen.getByPlaceholderText(/add a comment/i)
+    fireEvent.change(textarea, { target: { value: '   ' } })
+    // Button should be disabled for whitespace
+    expect(screen.getByRole('button', { name: /send/i })).toBeDisabled()
+  })
+})


### PR DESCRIPTION
## Summary
- **Toast errors**: CommentInput now shows error toasts via `useToast` instead of inline error text
- **Mobile responsive**: Send button goes full-width on small screens (`max-sm:w-full`), compact timestamps in CommentThread
- **Scroll to comments**: TaskDetail auto-scrolls to the comments section when opening an AWAITING_OWNER task
- **Tests**: 11 new tests for CommentThread (rendering, emojis, timestamps, empty state) and CommentInput (send, Ctrl+Enter, toast on error, whitespace guard)

## Acceptance Criteria
- [x] Comment input visible on AWAITING_OWNER task detail
- [x] Send creates USER_COMMENT event via API
- [x] Comment thread renders past comments with author + time
- [x] Ctrl+Enter sends
- [x] Comment input hidden when task not in AWAITING_OWNER
- [x] Past comments visible in all states (read-only)
- [x] Amber 💬 indicator on AWAITING_OWNER cards
- [x] Mobile: full-width textarea and send button

## Test plan
- [ ] Run `npx vitest run tests/client/comment-system.test.tsx` — 11 tests pass
- [ ] Run full suite `npx vitest run` — all 148 tests pass
- [ ] Verify AWAITING_OWNER task detail scrolls to comment section on open
- [ ] Verify toast appears on comment send failure
- [ ] Verify mobile layout at 390px viewport

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)