### PR TITLE
fix(#84): widen OrgChart root node to prevent role truncation

### DIFF
--- a/src/components/agents/OrgChart.tsx
+++ b/src/components/agents/OrgChart.tsx
@@ -66,7 +66,7 @@ function buildTree(agents: AgentInfo[]): TreeNode | null {
 }
 
 /** Layout constants */
-const ROOT_W = 80
+const ROOT_W = 96
 const ROOT_H = 100
 const CHILD_DIAMETER = 48
 const CHILD_R = CHILD_DIAMETER / 2
@@ -154,7 +154,7 @@ export default function OrgChart({ onSelectAgent }: OrgChartProps) {
   if (loading) {
     return (
       <div className="flex items-center gap-8 py-8">
-        <Skeleton className="w-20 h-[100px] rounded-md" />
+        <Skeleton className="w-24 h-[100px] rounded-md" />
         <div className="flex flex-col gap-3">
           {Array.from({ length: 4 }).map((_, i) => (
             <Skeleton key={i} className="w-12 h-12 rounded-full" />

--- a/src/components/agents/OrgNode.tsx
+++ b/src/components/agents/OrgNode.tsx
@@ -26,7 +26,8 @@ export default function OrgNode({ agent, isRoot, isSelected, onClick }: OrgNodeP
         className={`relative flex flex-col items-center justify-center gap-1 rounded-md border bg-bg-elevated transition-colors duration-100 focus:outline-none focus:ring-1 focus:ring-accent-amber/40 ${
           isSelected ? 'border-accent-amber' : 'border-border-subtle'
         } ${isActive ? 'ring-1 ring-accent-amber/50 animate-pulse-active' : ''}`}
-        style={{ width: 80, height: 100 }}
+        title={`${agent.name} — ${agent.role}`}
+        style={{ width: 96, height: 100 }}
       >
         <span className="text-2xl leading-none">{agent.emoji}</span>
         <span className="text-[13px] font-semibold text-text-primary leading-tight text-center px-1 truncate w-full">

--- a/tests/client/org-chart-hierarchy.test.tsx
+++ b/tests/client/org-chart-hierarchy.test.tsx
@@ -121,9 +121,9 @@ describe('OrgChart hierarchy', () => {
     render(<OrgChart onSelectAgent={vi.fn()} />)
     await act(async () => { await vi.advanceTimersByTimeAsync(0) })
 
-    // Root OrgNode renders as a button with inline style { width: 80, height: 100 }
+    // Root OrgNode renders as a button with inline style { width: 96, height: 100 }
     const rootButton = screen.getAllByRole('button').find(
-      b => b.style.width === '80px',
+      b => b.style.width === '96px',
     )
     expect(rootButton).toBeDefined()
     expect(rootButton!.textContent).toContain('Сократ')


### PR DESCRIPTION
## Summary
- Increased OrgChart root node width from 80px to 96px so "orchestrator" role text displays fully
- Added `title` tooltip on root node for hover showing name and role
- Updated skeleton loader width (`w-20` → `w-24`) to match new root width
- Updated test assertion for new root width

## Linked Issue
Closes #84

## Test plan
- [x] All 16 existing OrgChart tests pass
- [x] TypeScript typecheck clean
- [x] ESLint clean
- [ ] Visual check: root node role text fully visible, no layout overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)