### PR TITLE
fix(#83): TopBar AWAITING_OWNER badge — testids + component tests

### DIFF
--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -22,14 +22,17 @@ function Pill({
   children,
   onClick,
   className = '',
+  'data-testid': testId,
 }: {
   children: React.ReactNode
   onClick?: () => void
   className?: string
+  'data-testid'?: string
 }) {
   return (
     <button
       onClick={onClick}
+      data-testid={testId}
       className={`flex items-center gap-1.5 rounded-full px-3 py-1 bg-bg-elevated border border-border-subtle hover:bg-bg-hover transition-colors shrink-0 ${className}`}
     >
       {children}
@@ -92,9 +95,9 @@ export default function TopBar({ status, onMenuToggle }: TopBarProps) {
 
       {/* Awaiting owner pill */}
       {status?.awaiting_owner_count != null && status.awaiting_owner_count > 0 && (
-        <Pill onClick={() => navigate('/')} className="hidden sm:flex">
+        <Pill onClick={() => navigate('/')} className="hidden sm:flex" data-testid="awaiting-owner-pill">
           {status?.awaiting_owner_overdue && (
-            <span className="inline-block w-2 h-2 rounded-full shrink-0 bg-red animate-pulse-critical" />
+            <span data-testid="awaiting-owner-pulse" className="inline-block w-2 h-2 rounded-full shrink-0 bg-red animate-pulse-critical" />
           )}
           <span className="text-xs text-amber">⏳ {status.awaiting_owner_count}</span>
         </Pill>

--- a/tests/client/topbar-awaiting-badge.test.tsx
+++ b/tests/client/topbar-awaiting-badge.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen, cleanup } from '@testing-library/react'
+import { describe, it, expect, afterEach } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
+
+import TopBar from '../../src/components/layout/TopBar'
+import type { GlobalStatus } from '../../src/lib/types'
+
+function makeStatus(overrides: Partial<GlobalStatus> = {}): GlobalStatus {
+  return {
+    gateway_up: true,
+    agents_alive: 2,
+    agents_total: 9,
+    active_tasks: 1,
+    blocked_tasks: 0,
+    stuck_tasks: 0,
+    failed_services: 0,
+    cpu_percent: 25,
+    cpu_temp: 55,
+    claude_usage_percent: 40,
+    codex_usage_percent: 20,
+    awaiting_owner_count: 0,
+    awaiting_owner_overdue: false,
+    timestamp: new Date().toISOString(),
+    ...overrides,
+  }
+}
+
+function renderTopBar(status: GlobalStatus | null) {
+  return render(
+    <MemoryRouter>
+      <TopBar status={status} />
+    </MemoryRouter>,
+  )
+}
+
+describe('TopBar — AWAITING_OWNER badge', () => {
+  afterEach(cleanup)
+
+  it('shows badge when awaiting_owner_count > 0', () => {
+    renderTopBar(makeStatus({ awaiting_owner_count: 3 }))
+    const pill = screen.getByTestId('awaiting-owner-pill')
+    expect(pill).toBeInTheDocument()
+    expect(pill.textContent).toContain('⏳')
+    expect(pill.textContent).toContain('3')
+  })
+
+  it('hides badge when awaiting_owner_count is 0', () => {
+    renderTopBar(makeStatus({ awaiting_owner_count: 0 }))
+    expect(screen.queryByTestId('awaiting-owner-pill')).not.toBeInTheDocument()
+  })
+
+  it('hides badge when status is null', () => {
+    renderTopBar(null)
+    expect(screen.queryByTestId('awaiting-owner-pill')).not.toBeInTheDocument()
+  })
+
+  it('shows pulse dot when awaiting_owner_overdue is true', () => {
+    renderTopBar(makeStatus({ awaiting_owner_count: 2, awaiting_owner_overdue: true }))
+    const pulse = screen.getByTestId('awaiting-owner-pulse')
+    expect(pulse).toBeInTheDocument()
+    expect(pulse.className).toContain('animate-pulse-critical')
+    expect(pulse.className).toContain('bg-red')
+  })
+
+  it('does not show pulse dot when awaiting_owner_overdue is false', () => {
+    renderTopBar(makeStatus({ awaiting_owner_count: 2, awaiting_owner_overdue: false }))
+    expect(screen.getByTestId('awaiting-owner-pill')).toBeInTheDocument()
+    expect(screen.queryByTestId('awaiting-owner-pulse')).not.toBeInTheDocument()
+  })
+
+  it('displays correct count value', () => {
+    renderTopBar(makeStatus({ awaiting_owner_count: 7 }))
+    const pill = screen.getByTestId('awaiting-owner-pill')
+    expect(pill.textContent).toContain('7')
+  })
+})


### PR DESCRIPTION
## Summary
- Added `data-testid` attributes to the AWAITING_OWNER pill and pulse dot in TopBar for testability
- Added 6 component tests (`topbar-awaiting-badge.test.tsx`) verifying all acceptance criteria:
  - Badge visible when `awaiting_owner_count > 0`
  - Pulse animation (`.animate-pulse-critical`) when `awaiting_owner_overdue` is true
  - Badge hidden when count is 0 or status is null

## Context
Closes #83. The TopBar badge logic was already correct (conditional render on count > 0, pulse on overdue). The visual review finding was most likely caused by no AWAITING_OWNER tasks existing in the system at review time. This PR adds test coverage to prevent future regressions.

## Test plan
- [x] All 6 new tests pass (`npx vitest run tests/client/topbar-awaiting-badge.test.tsx`)
- [x] Full suite passes (154/154)
- [x] TypeScript typecheck clean
- [x] ESLint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)