### PR TITLE
fix(#111): default Pipeline stateGroup to 'active'

### DIFF
--- a/src/pages/Pipeline.tsx
+++ b/src/pages/Pipeline.tsx
@@ -226,13 +226,20 @@ export default function Pipeline() {
   const { data: tasks, loading, refresh } = usePolling(fetchTasksFn, 5000);
   const [selectedTask, setSelectedTask] = useState<Task | null>(null);
   const [showCreate, setShowCreate] = useState(false);
-  const [filters, setFilters] = useState<Filters>({
-    owners: [],
-    route: '',
-    stateGroup: 'all',
+  const [filters, setFilters] = useState<Filters>(() => {
+    const saved = localStorage.getItem('pipeline:stateGroup');
+    const stateGroup = (saved === 'all' || saved === 'active' || saved === 'terminal' || saved === 'error')
+      ? saved as StateGroup
+      : 'active';
+    return { owners: [], route: '', stateGroup };
   });
   const [hideEmpty, setHideEmpty] = useState(false);
   const [lastUpdated, setLastUpdated] = useState<number>(Date.now());
+
+  // Persist stateGroup selection to localStorage
+  useEffect(() => {
+    localStorage.setItem('pipeline:stateGroup', filters.stateGroup);
+  }, [filters.stateGroup]);
 
   const allOwners = useMemo(() => {
     if (!tasks) return [];

--- a/tests/client/pipeline-page.test.tsx
+++ b/tests/client/pipeline-page.test.tsx
@@ -106,10 +106,12 @@ const mockTasks: Task[] = [
 describe('Pipeline page (full Kanban)', () => {
   afterEach(() => {
     cleanup()
+    localStorage.clear()
   })
 
   beforeEach(() => {
     vi.clearAllMocks()
+    localStorage.clear()
     vi.mocked(usePolling).mockReturnValue({
       data: mockTasks,
       loading: false,
@@ -119,19 +121,36 @@ describe('Pipeline page (full Kanban)', () => {
     })
   })
 
-  it('renders KanbanBoard with pipeline columns', () => {
+  it('defaults stateGroup to active on mount', () => {
     render(<Pipeline />)
-    // Verify the page renders and shows state column headers
+    // EXECUTION is an active state — should be visible
+    expect(screen.getByText('EXECUTION')).toBeInTheDocument()
+    // Build feature X is in EXECUTION (active) — should be visible
+    expect(screen.getByText('Build feature X')).toBeInTheDocument()
+    // DONE tasks should NOT appear with active default
+    expect(screen.queryByText('Deploy service Y')).not.toBeInTheDocument()
+  })
+
+  it('renders all columns when stateGroup is set to all via localStorage', () => {
+    localStorage.setItem('pipeline:stateGroup', 'all')
+    render(<Pipeline />)
     expect(screen.getByText('EXECUTION')).toBeInTheDocument()
     expect(screen.getByText('DONE')).toBeInTheDocument()
     expect(screen.getByText('BLOCKED')).toBeInTheDocument()
   })
 
-  it('displays task cards in correct columns', () => {
+  it('displays task cards in correct columns when stateGroup=all', () => {
+    localStorage.setItem('pipeline:stateGroup', 'all')
     render(<Pipeline />)
     expect(screen.getByText('Build feature X')).toBeInTheDocument()
     expect(screen.getByText('Deploy service Y')).toBeInTheDocument()
     expect(screen.getByText('Design review blocked')).toBeInTheDocument()
+  })
+
+  it('persists stateGroup selection to localStorage', () => {
+    render(<Pipeline />)
+    // Default 'active' should be saved
+    expect(localStorage.getItem('pipeline:stateGroup')).toBe('active')
   })
 
   it('shows freshness indicator', () => {


### PR DESCRIPTION
## Summary
- Default `stateGroup` filter changed from `'all'` to `'active'` so Pipeline opens showing only active columns instead of 15+ empty ones
- User's stateGroup selection persisted to `localStorage` (`pipeline:stateGroup` key) so it survives page reloads
- "All states" option remains in the dropdown for manual access

Closes #111

## Test plan
- [x] `stateGroup` defaults to `'active'` on mount (new test)
- [x] DONE tasks hidden by default (new test)
- [x] `localStorage` restores previous selection (new test)
- [x] Persistence writes to `localStorage` on mount (new test)
- [x] All 7 pipeline-page tests pass
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)