### PR TITLE
fix(#113): hide Artifacts dead zone in TaskDetail

### DIFF
--- a/src/components/pipeline/TaskDetail.tsx
+++ b/src/components/pipeline/TaskDetail.tsx
@@ -79,9 +79,6 @@ export function TaskDetail({ task, onClose, onTransition }: TaskDetailProps) {
     }
   }, [task.id]);
 
-  // Subdirectories for artifacts
-  const artifactDirs = ['issue-contracts', 'outputs', 'execution-bundles', 'review-findings'];
-
   const commentList: import('../../lib/types').CommentEvent[] = events
     .filter((e) => e.event_type === 'USER_COMMENT' || e['type'] === 'USER_COMMENT')
     .map((e) => {
@@ -212,22 +209,24 @@ export function TaskDetail({ task, onClose, onTransition }: TaskDetailProps) {
               </section>
             )}
 
-            {/* Sub-artifacts */}
-            <section>
-              <h3 className="text-sm font-semibold text-text-secondary uppercase tracking-wider mb-2">
-                Artifacts
-              </h3>
-              <div className="space-y-1">
-                {artifactDirs.map((dir) => (
-                  <div
-                    key={dir}
-                    className="px-2 py-1.5 rounded-sm bg-bg-surface text-sm font-mono text-text-secondary"
-                  >
-                    {dir}/
-                  </div>
-                ))}
-              </div>
-            </section>
+            {/* Artifacts — only shown when real files exist */}
+            {task.artifacts && task.artifacts.length > 0 && (
+              <section data-testid="artifacts-section">
+                <h3 className="text-sm font-semibold text-text-secondary uppercase tracking-wider mb-2">
+                  Artifacts
+                </h3>
+                <div className="space-y-1">
+                  {task.artifacts.map((artifact) => (
+                    <div
+                      key={artifact}
+                      className="px-2 py-1.5 rounded-sm bg-bg-surface text-sm font-mono text-text-secondary"
+                    >
+                      {artifact}
+                    </div>
+                  ))}
+                </div>
+              </section>
+            )}
 
             {/* Action buttons */}
             <section>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -119,6 +119,7 @@ export interface Task {
   contract?: TaskContract;
   events?: TaskEvent[];
   decisions?: TaskDecision[];
+  artifacts?: string[];
 }
 
 export interface TransitionError {

--- a/tests/client/task-detail-artifacts.test.tsx
+++ b/tests/client/task-detail-artifacts.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen, cleanup, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+
+// Mock api — TaskDetail fetches events, decisions, contract on mount
+vi.mock('../../src/lib/api', () => ({
+  fetchTaskEvents: vi.fn().mockResolvedValue([]),
+  fetchTaskDecisions: vi.fn().mockResolvedValue([]),
+  fetchTaskContract: vi.fn().mockResolvedValue(null),
+  transitionTask: vi.fn(),
+  addTaskEvent: vi.fn(),
+}))
+
+import { TaskDetail } from '../../src/components/pipeline/TaskDetail'
+import type { Task } from '../../src/lib/types'
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: 'tsk_test_001',
+    state: 'BACKLOG',
+    owner: 'archimedes',
+    route: 'codex',
+    title: 'Test Task',
+    age: 0,
+    ttl: null,
+    blockers: 0,
+    retries: 0,
+    terminal: false,
+    hasQuality: false,
+    hasOutcome: false,
+    hasRelease: false,
+    ...overrides,
+  }
+}
+
+describe('TaskDetail — Artifacts section', () => {
+  afterEach(cleanup)
+
+  it('does not render Artifacts section when task has no artifacts', async () => {
+    render(<TaskDetail task={makeTask()} onClose={vi.fn()} onTransition={vi.fn()} />)
+
+    await waitFor(() => {
+      expect(screen.queryByText('Loading...')).not.toBeInTheDocument()
+    })
+
+    expect(screen.queryByTestId('artifacts-section')).not.toBeInTheDocument()
+    expect(screen.queryByText('Artifacts')).not.toBeInTheDocument()
+  })
+
+  it('does not render Artifacts section when artifacts is empty array', async () => {
+    render(<TaskDetail task={makeTask({ artifacts: [] })} onClose={vi.fn()} onTransition={vi.fn()} />)
+
+    await waitFor(() => {
+      expect(screen.queryByText('Loading...')).not.toBeInTheDocument()
+    })
+
+    expect(screen.queryByTestId('artifacts-section')).not.toBeInTheDocument()
+  })
+
+  it('renders Artifacts section when task has artifacts', async () => {
+    const artifacts = ['output/report.md', 'output/summary.json']
+    render(
+      <TaskDetail task={makeTask({ artifacts })} onClose={vi.fn()} onTransition={vi.fn()} />,
+    )
+
+    await waitFor(() => {
+      expect(screen.queryByText('Loading...')).not.toBeInTheDocument()
+    })
+
+    expect(screen.getByTestId('artifacts-section')).toBeInTheDocument()
+    expect(screen.getByText('output/report.md')).toBeInTheDocument()
+    expect(screen.getByText('output/summary.json')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary

- Removed static Artifacts section from TaskDetail that displayed hardcoded directory names (`issue-contracts/`, `outputs/`, etc.) with no real content — a dead zone that reduced user trust
- Section now conditionally renders only when `task.artifacts` has items, ready for future backend endpoint
- Added `artifacts?: string[]` field to the `Task` type interface

Closes #113

## Test plan

- [x] `TaskDetail` without artifacts prop does not render ArtifactsSection
- [x] `TaskDetail` with empty artifacts array does not render section
- [x] `TaskDetail` with artifacts renders items correctly
- [x] TypeScript compiles clean
- [x] ESLint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)