### PR TITLE
feat(#118): add hover tooltips to Q/O/R icons in TaskCard

### DIFF
--- a/src/components/pipeline/TaskCard.tsx
+++ b/src/components/pipeline/TaskCard.tsx
@@ -103,7 +103,10 @@ export function TaskCard({ task, onClick, error }: TaskCardProps) {
 
           {/* Retries */}
           {task.retries > 0 && (
-            <span className="inline-flex items-center px-1.5 py-0.5 rounded-sm bg-amber-subtle text-amber font-mono text-xs">
+            <span
+              title={`${task.retries} ${task.retries === 1 ? 'retry' : 'retries'}`}
+              className="inline-flex items-center px-1.5 py-0.5 rounded-sm bg-amber-subtle text-amber font-mono text-xs cursor-help"
+            >
               {task.retries}r
             </span>
           )}
@@ -111,13 +114,13 @@ export function TaskCard({ task, onClick, error }: TaskCardProps) {
           {/* Artifact icons */}
           <div className="flex items-center gap-1 ml-auto">
             {task.hasQuality && (
-              <span className="text-xs text-emerald font-mono" title="Quality report">Q</span>
+              <span className="text-xs text-emerald font-mono cursor-help" title="Quality gate passed">Q</span>
             )}
             {task.hasOutcome && (
-              <span className="text-xs text-blue font-mono" title="Outcome manifest">O</span>
+              <span className="text-xs text-blue font-mono cursor-help" title="Owner confirmed">O</span>
             )}
             {task.hasRelease && (
-              <span className="text-xs text-amber font-mono" title="Release evidence">R</span>
+              <span className="text-xs text-amber font-mono cursor-help" title="Release evidence">R</span>
             )}
           </div>
         </div>

--- a/tests/client/taskcard-tooltips.test.tsx
+++ b/tests/client/taskcard-tooltips.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen, cleanup } from '@testing-library/react'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import type { Task, PipelineState } from '../../src/lib/types'
+
+vi.mock('@dnd-kit/sortable', () => ({
+  useSortable: vi.fn(() => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: vi.fn(),
+    transform: null,
+    transition: null,
+    isDragging: false,
+  })),
+}))
+
+vi.mock('@dnd-kit/utilities', () => ({
+  CSS: { Transform: { toString: () => undefined } },
+}))
+
+import { TaskCard } from '../../src/components/pipeline/TaskCard'
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: 'tsk_tooltip',
+    state: 'EXECUTION' as PipelineState,
+    owner: 'archimedes',
+    route: 'build_route',
+    title: 'Tooltip test task',
+    age: 10,
+    ttl: null,
+    blockers: 0,
+    retries: 0,
+    terminal: false,
+    hasQuality: false,
+    hasOutcome: false,
+    hasRelease: false,
+    actors: [],
+    ...overrides,
+  }
+}
+
+describe('TaskCard Q/O/R hover tooltips', () => {
+  afterEach(() => cleanup())
+
+  it('shows retries tooltip with plural form for retries=2', () => {
+    render(<TaskCard task={makeTask({ retries: 2 })} onClick={vi.fn()} />)
+    const el = screen.getByTitle('2 retries')
+    expect(el).toBeTruthy()
+    expect(el.className).toContain('cursor-help')
+  })
+
+  it('shows retries tooltip with singular form for retries=1', () => {
+    render(<TaskCard task={makeTask({ retries: 1 })} onClick={vi.fn()} />)
+    const el = screen.getByTitle('1 retry')
+    expect(el).toBeTruthy()
+    expect(el.className).toContain('cursor-help')
+  })
+
+  it('shows "Quality gate passed" tooltip on Q icon', () => {
+    render(<TaskCard task={makeTask({ hasQuality: true })} onClick={vi.fn()} />)
+    const el = screen.getByTitle('Quality gate passed')
+    expect(el).toBeTruthy()
+    expect(el.textContent).toBe('Q')
+    expect(el.className).toContain('cursor-help')
+  })
+
+  it('shows "Owner confirmed" tooltip on O icon', () => {
+    render(<TaskCard task={makeTask({ hasOutcome: true })} onClick={vi.fn()} />)
+    const el = screen.getByTitle('Owner confirmed')
+    expect(el).toBeTruthy()
+    expect(el.textContent).toBe('O')
+    expect(el.className).toContain('cursor-help')
+  })
+
+  it('all three tooltips render together', () => {
+    render(
+      <TaskCard
+        task={makeTask({ retries: 2, hasQuality: true, hasOutcome: true })}
+        onClick={vi.fn()}
+      />
+    )
+    expect(screen.getByTitle('2 retries')).toBeTruthy()
+    expect(screen.getByTitle('Quality gate passed')).toBeTruthy()
+    expect(screen.getByTitle('Owner confirmed')).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## Summary
- Added native `title` tooltips to the retries badge ("N retries"/"1 retry"), Quality icon ("Quality gate passed"), and Owner icon ("Owner confirmed") in TaskCard
- Added `cursor-help` class to all indicator icons so users get visual feedback that tooltips are available
- Added 5 tests covering singular/plural retries, individual tooltips, and all-three-together rendering

Closes #118

## Test plan
- [x] `npx vitest run tests/client/taskcard-tooltips.test.tsx` — 5 tests pass
- [x] Full suite — 212 tests pass, no regressions
- [x] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)