### PR TITLE
fix(#121): hide system metrics from TopBar on non-system routes

### DIFF
--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useLocation } from 'react-router-dom'
 import type { GlobalStatus } from '../../lib/types'
 
 interface TopBarProps {
@@ -64,6 +64,8 @@ function TempDisplay({ temp }: { temp: number | null }) {
 
 export default function TopBar({ status, onMenuToggle }: TopBarProps) {
   const navigate = useNavigate()
+  const { pathname } = useLocation()
+  const isSystemPage = pathname === '/system'
 
   return (
     <header className="h-[var(--topbar-height)] bg-bg-surface border-b border-border-subtle flex items-center px-3 gap-2 shrink-0 overflow-hidden">
@@ -125,23 +127,28 @@ export default function TopBar({ status, onMenuToggle }: TopBarProps) {
 
       <div className="flex-1" />
 
-      {/* CPU pill */}
-      <Pill onClick={() => navigate('/system')} className="hidden md:flex">
-        <span className="text-xs text-text-secondary">CPU</span>
-        <span className="text-xs font-mono text-text-primary">
-          {status?.cpu_percent != null ? `${status.cpu_percent}%` : '—'}
-        </span>
-        <TempDisplay temp={status?.cpu_temp ?? null} />
-      </Pill>
+      {/* CPU pill — system page only */}
+      {isSystemPage && (
+        <Pill onClick={() => navigate('/system')} className="hidden md:flex" data-testid="cpu-pill">
+          <span className="text-xs text-text-secondary">CPU</span>
+          <span className="text-xs font-mono text-text-primary">
+            {status?.cpu_percent != null ? `${status.cpu_percent}%` : '—'}
+          </span>
+          <TempDisplay temp={status?.cpu_temp ?? null} />
+        </Pill>
+      )}
 
-      {/* Usage bars */}
-      <button
-        onClick={() => navigate('/config')}
-        className="hidden lg:flex items-center gap-3 hover:bg-bg-hover rounded-full px-3 py-1 transition-colors shrink-0"
-      >
-        <UsageBar label="Claude" percent={status?.claude_usage_percent ?? null} />
-        <UsageBar label="Codex" percent={status?.codex_usage_percent ?? null} />
-      </button>
+      {/* Usage bars — system page only */}
+      {isSystemPage && (
+        <button
+          onClick={() => navigate('/config')}
+          data-testid="usage-bars"
+          className="hidden lg:flex items-center gap-3 hover:bg-bg-hover rounded-full px-3 py-1 transition-colors shrink-0"
+        >
+          <UsageBar label="Claude" percent={status?.claude_usage_percent ?? null} />
+          <UsageBar label="Codex" percent={status?.codex_usage_percent ?? null} />
+        </button>
+      )}
     </header>
   )
 }

--- a/tests/client/topbar-system-metrics.test.tsx
+++ b/tests/client/topbar-system-metrics.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen, cleanup } from '@testing-library/react'
+import { describe, it, expect, afterEach } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
+
+import TopBar from '../../src/components/layout/TopBar'
+import type { GlobalStatus } from '../../src/lib/types'
+
+function makeStatus(overrides: Partial<GlobalStatus> = {}): GlobalStatus {
+  return {
+    gateway_up: true,
+    agents_alive: 2,
+    agents_total: 9,
+    active_tasks: 1,
+    blocked_tasks: 0,
+    stuck_tasks: 0,
+    failed_services: 0,
+    cpu_percent: 25,
+    cpu_temp: 55,
+    claude_usage_percent: 40,
+    codex_usage_percent: 20,
+    awaiting_owner_count: 0,
+    awaiting_owner_overdue: false,
+    timestamp: new Date().toISOString(),
+    ...overrides,
+  }
+}
+
+function renderTopBar(status: GlobalStatus | null, route = '/') {
+  return render(
+    <MemoryRouter initialEntries={[route]}>
+      <TopBar status={status} />
+    </MemoryRouter>,
+  )
+}
+
+describe('TopBar — system metrics visibility', () => {
+  afterEach(cleanup)
+
+  it('does not render CPU pill on non-system routes', () => {
+    renderTopBar(makeStatus(), '/')
+    expect(screen.queryByTestId('cpu-pill')).not.toBeInTheDocument()
+  })
+
+  it('does not render usage bars on non-system routes', () => {
+    renderTopBar(makeStatus(), '/ideas')
+    expect(screen.queryByTestId('usage-bars')).not.toBeInTheDocument()
+  })
+
+  it('renders CPU pill on /system route', () => {
+    renderTopBar(makeStatus(), '/system')
+    expect(screen.getByTestId('cpu-pill')).toBeInTheDocument()
+    expect(screen.getByTestId('cpu-pill').textContent).toContain('CPU')
+    expect(screen.getByTestId('cpu-pill').textContent).toContain('25%')
+  })
+
+  it('renders usage bars on /system route', () => {
+    renderTopBar(makeStatus(), '/system')
+    expect(screen.getByTestId('usage-bars')).toBeInTheDocument()
+    expect(screen.getByTestId('usage-bars').textContent).toContain('Claude')
+    expect(screen.getByTestId('usage-bars').textContent).toContain('Codex')
+  })
+
+  it('always renders GW pill regardless of route', () => {
+    renderTopBar(makeStatus(), '/')
+    expect(screen.getByText('GW')).toBeInTheDocument()
+  })
+
+  it('always renders Agents pill regardless of route', () => {
+    renderTopBar(makeStatus(), '/ideas')
+    expect(screen.getByText('Agents')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- CPU%, CPU temp, Claude usage%, and Codex usage% pills are now conditionally rendered only on `/system` page
- GW status dot, Agents N/total, AWAITING_OWNER badge, Active/Blocked pills remain visible on all routes
- Uses `useLocation()` to detect current route — zero new dependencies

Closes #121

## Test plan
- [x] New test: `topbar-system-metrics.test.tsx` — 6 tests covering visibility on system vs non-system routes
- [x] Existing `topbar-awaiting-badge.test.tsx` — all 6 tests pass (no regression)
- [x] Full client test suite — 164/164 tests pass
- [x] TypeScript typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)