### PR TITLE
feat(#122): QuickSearch — Cmd+K command palette for pipeline tasks

### DIFF
--- a/src/components/pipeline/QuickSearch.tsx
+++ b/src/components/pipeline/QuickSearch.tsx
@@ -1,0 +1,147 @@
+import { useState, useEffect, useRef, useMemo } from 'react'
+import type { Task } from '../../lib/types'
+
+interface QuickSearchProps {
+  tasks: Task[]
+  open: boolean
+  onSelect: (task: Task) => void
+  onClose: () => void
+}
+
+function highlightMatch(text: string, query: string): React.ReactNode {
+  if (!query) return text
+  const idx = text.toLowerCase().indexOf(query.toLowerCase())
+  if (idx === -1) return text
+  return (
+    <>
+      {text.slice(0, idx)}
+      <mark
+        data-testid="quick-search-highlight"
+        className="bg-amber-subtle text-amber rounded-sm px-0.5"
+      >
+        {text.slice(idx, idx + query.length)}
+      </mark>
+      {text.slice(idx + query.length)}
+    </>
+  )
+}
+
+export function QuickSearch({ tasks, open, onSelect, onClose }: QuickSearchProps) {
+  const [query, setQuery] = useState('')
+  const [activeIndex, setActiveIndex] = useState(0)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const results = useMemo(() => {
+    const q = query.toLowerCase()
+    return tasks
+      .filter(
+        (t) =>
+          t.title.toLowerCase().includes(q) ||
+          t.id.toLowerCase().startsWith(q)
+      )
+      .slice(0, 10)
+  }, [tasks, query])
+
+  // Reset state when opening
+  useEffect(() => {
+    if (open) {
+      setQuery('')
+      setActiveIndex(0)
+      // Focus input after render
+      requestAnimationFrame(() => inputRef.current?.focus())
+    }
+  }, [open])
+
+  // Keep activeIndex in bounds
+  useEffect(() => {
+    if (activeIndex >= results.length) {
+      setActiveIndex(Math.max(0, results.length - 1))
+    }
+  }, [results.length, activeIndex])
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    switch (e.key) {
+      case 'Escape':
+        onClose()
+        break
+      case 'ArrowDown':
+        e.preventDefault()
+        setActiveIndex((i) => Math.min(i + 1, results.length - 1))
+        break
+      case 'ArrowUp':
+        e.preventDefault()
+        setActiveIndex((i) => Math.max(i - 1, 0))
+        break
+      case 'Enter':
+        e.preventDefault()
+        if (results[activeIndex]) {
+          onSelect(results[activeIndex])
+        }
+        break
+    }
+  }
+
+  if (!open) return null
+
+  return (
+    <>
+      <div
+        data-testid="quick-search-backdrop"
+        className="fixed inset-0 bg-black/50 z-50"
+        onClick={onClose}
+      />
+      <div className="fixed top-[20%] left-1/2 -translate-x-1/2 z-50 w-[480px] max-w-[90vw] bg-bg-elevated border border-border-subtle rounded-lg shadow-panel animate-fade-in">
+        <div className="p-3 border-b border-border-subtle">
+          <input
+            ref={inputRef}
+            type="text"
+            value={query}
+            onChange={(e) => {
+              setQuery(e.target.value)
+              setActiveIndex(0)
+            }}
+            onKeyDown={handleKeyDown}
+            placeholder="Search tasks by title or ID..."
+            className="w-full bg-bg-void border border-border-default rounded-sm px-3 py-2 text-sm font-mono text-text-primary focus:border-amber focus:outline-none"
+          />
+        </div>
+        <div className="max-h-[320px] overflow-y-auto p-1">
+          {results.length === 0 ? (
+            <div className="px-3 py-6 text-center text-sm text-text-tertiary">
+              No tasks found
+            </div>
+          ) : (
+            results.map((task, i) => (
+              <button
+                key={task.id}
+                data-testid="quick-search-result"
+                data-active={i === activeIndex ? 'true' : 'false'}
+                onClick={() => onSelect(task)}
+                className={`w-full text-left px-3 py-2 rounded-sm flex items-center gap-3 transition-colors ${
+                  i === activeIndex
+                    ? 'bg-bg-hover text-text-primary'
+                    : 'text-text-secondary hover:bg-bg-hover'
+                }`}
+              >
+                <span className="text-xs font-mono text-text-tertiary shrink-0">
+                  {task.id}
+                </span>
+                <span className="text-sm truncate">
+                  {highlightMatch(task.title, query)}
+                </span>
+                <span className="ml-auto text-[10px] font-mono text-text-disabled shrink-0">
+                  {task.state}
+                </span>
+              </button>
+            ))
+          )}
+        </div>
+        <div className="px-3 py-2 border-t border-border-subtle flex gap-3 text-[10px] text-text-disabled font-mono">
+          <span>↑↓ navigate</span>
+          <span>↵ open</span>
+          <span>esc close</span>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/src/pages/Pipeline.tsx
+++ b/src/pages/Pipeline.tsx
@@ -12,6 +12,7 @@ import { usePolling } from '../hooks/usePolling';
 import { KanbanBoard } from '../components/pipeline/KanbanBoard';
 import { TaskDetail } from '../components/pipeline/TaskDetail';
 import { MultiSelect } from '../components/ui/MultiSelect';
+import { QuickSearch } from '../components/pipeline/QuickSearch';
 
 // ─── Freshness Indicator ──────────────────────────────────────────────────────
 
@@ -319,6 +320,7 @@ export default function Pipeline() {
   );
 
   const [hideEmpty, setHideEmpty] = useState(false);
+  const [showSearch, setShowSearch] = useState(false);
   const [lastUpdated, setLastUpdated] = useState<number>(Date.now());
 
   // Fetch current agent identity on mount
@@ -359,6 +361,23 @@ export default function Pipeline() {
   useEffect(() => {
     if (tasks) setLastUpdated(Date.now());
   }, [tasks]);
+
+  // Cmd+K / Ctrl+K to open quick search
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+        e.preventDefault()
+        setShowSearch(true)
+      }
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [])
+
+  const handleSearchSelect = useCallback((task: Task) => {
+    setShowSearch(false)
+    setSelectedTask(task)
+  }, [])
 
   const handleCardClick = useCallback((task: Task) => {
     setSelectedTask(task);
@@ -422,6 +441,14 @@ export default function Pipeline() {
           onTransition={handleTransition}
         />
       )}
+
+      {/* Quick search overlay */}
+      <QuickSearch
+        tasks={tasks || []}
+        open={showSearch}
+        onSelect={handleSearchSelect}
+        onClose={() => setShowSearch(false)}
+      />
 
       {/* Create task modal */}
       {showCreate && (

--- a/tests/client/quick-search.test.tsx
+++ b/tests/client/quick-search.test.tsx
@@ -1,0 +1,167 @@
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { QuickSearch } from '../../src/components/pipeline/QuickSearch'
+import type { Task } from '../../src/lib/types'
+
+function makeTask(overrides: Partial<Task>): Task {
+  return {
+    id: 'tsk_001',
+    state: 'EXECUTION',
+    owner: 'archimedes',
+    route: 'build_route',
+    title: 'Default task',
+    age: 10,
+    ttl: null,
+    blockers: 0,
+    retries: 0,
+    terminal: false,
+    hasQuality: false,
+    hasOutcome: false,
+    hasRelease: false,
+    ...overrides,
+  }
+}
+
+const sampleTasks: Task[] = [
+  makeTask({ id: 'tsk_001', title: 'Add quick search' }),
+  makeTask({ id: 'tsk_002', title: 'Fix pipeline bug' }),
+  makeTask({ id: 'tsk_003', title: 'Update dashboard layout' }),
+  makeTask({ id: 'tsk_010', title: 'Search improvements', state: 'DONE' }),
+]
+
+describe('QuickSearch', () => {
+  afterEach(cleanup)
+
+  const baseProps = {
+    tasks: sampleTasks,
+    onSelect: vi.fn(),
+  }
+
+  it('does not render when closed', () => {
+    render(<QuickSearch {...baseProps} open={false} onClose={vi.fn()} />)
+    expect(screen.queryByPlaceholderText(/search/i)).not.toBeInTheDocument()
+  })
+
+  it('renders search input when open', () => {
+    render(<QuickSearch {...baseProps} open={true} onClose={vi.fn()} />)
+    expect(screen.getByPlaceholderText(/search tasks/i)).toBeInTheDocument()
+  })
+
+  it('shows all tasks initially (up to 10)', () => {
+    render(<QuickSearch {...baseProps} open={true} onClose={vi.fn()} />)
+    expect(screen.getByText('Add quick search')).toBeInTheDocument()
+    expect(screen.getByText('Fix pipeline bug')).toBeInTheDocument()
+    expect(screen.getByText('Update dashboard layout')).toBeInTheDocument()
+    expect(screen.getByText('Search improvements')).toBeInTheDocument()
+  })
+
+  it('filters by title (partial match, case-insensitive)', () => {
+    render(<QuickSearch {...baseProps} open={true} onClose={vi.fn()} />)
+    fireEvent.change(screen.getByPlaceholderText(/search tasks/i), {
+      target: { value: 'search' },
+    })
+    const results = screen.getAllByTestId('quick-search-result')
+    expect(results).toHaveLength(2)
+    expect(screen.queryByText('Fix pipeline bug')).not.toBeInTheDocument()
+  })
+
+  it('filters by task ID (prefix match)', () => {
+    render(<QuickSearch {...baseProps} open={true} onClose={vi.fn()} />)
+    fireEvent.change(screen.getByPlaceholderText(/search tasks/i), {
+      target: { value: 'tsk_01' },
+    })
+    expect(screen.getByText('Search improvements')).toBeInTheDocument()
+    expect(screen.queryByText('Fix pipeline bug')).not.toBeInTheDocument()
+  })
+
+  it('limits results to 10', () => {
+    const manyTasks = Array.from({ length: 15 }, (_, i) =>
+      makeTask({ id: `tsk_${String(i).padStart(3, '0')}`, title: `Task ${i}` })
+    )
+    render(
+      <QuickSearch tasks={manyTasks} open={true} onSelect={vi.fn()} onClose={vi.fn()} />
+    )
+    const items = screen.getAllByTestId('quick-search-result')
+    expect(items.length).toBe(10)
+  })
+
+  it('calls onSelect when a result is clicked', () => {
+    const onSelect = vi.fn()
+    render(<QuickSearch {...baseProps} open={true} onSelect={onSelect} onClose={vi.fn()} />)
+    fireEvent.click(screen.getByText('Fix pipeline bug'))
+    expect(onSelect).toHaveBeenCalledWith(sampleTasks[1])
+  })
+
+  it('calls onSelect when Enter is pressed on highlighted result', () => {
+    const onSelect = vi.fn()
+    render(<QuickSearch {...baseProps} open={true} onSelect={onSelect} onClose={vi.fn()} />)
+    const input = screen.getByPlaceholderText(/search tasks/i)
+    // First item is highlighted by default, press Enter
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(onSelect).toHaveBeenCalledWith(sampleTasks[0])
+  })
+
+  it('calls onClose when Escape is pressed', () => {
+    const onClose = vi.fn()
+    render(<QuickSearch {...baseProps} open={true} onClose={onClose} />)
+    fireEvent.keyDown(screen.getByPlaceholderText(/search tasks/i), {
+      key: 'Escape',
+    })
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('calls onClose when backdrop is clicked', () => {
+    const onClose = vi.fn()
+    render(<QuickSearch {...baseProps} open={true} onClose={onClose} />)
+    fireEvent.click(screen.getByTestId('quick-search-backdrop'))
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('navigates results with arrow keys', () => {
+    const onSelect = vi.fn()
+    render(<QuickSearch {...baseProps} open={true} onSelect={onSelect} onClose={vi.fn()} />)
+    const input = screen.getByPlaceholderText(/search tasks/i)
+
+    // Default: first item highlighted
+    const items = screen.getAllByTestId('quick-search-result')
+    expect(items[0]).toHaveAttribute('data-active', 'true')
+
+    // Arrow down → second item
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+    expect(items[1]).toHaveAttribute('data-active', 'true')
+    expect(items[0]).toHaveAttribute('data-active', 'false')
+
+    // Arrow up → back to first
+    fireEvent.keyDown(input, { key: 'ArrowUp' })
+    expect(items[0]).toHaveAttribute('data-active', 'true')
+  })
+
+  it('includes DONE tasks in search results', () => {
+    render(<QuickSearch {...baseProps} open={true} onClose={vi.fn()} />)
+    fireEvent.change(screen.getByPlaceholderText(/search tasks/i), {
+      target: { value: 'improvements' },
+    })
+    const results = screen.getAllByTestId('quick-search-result')
+    expect(results).toHaveLength(1)
+    // The DONE task (tsk_010) should be in results
+    expect(screen.getByText('tsk_010')).toBeInTheDocument()
+  })
+
+  it('highlights matching text in results', () => {
+    render(<QuickSearch {...baseProps} open={true} onClose={vi.fn()} />)
+    fireEvent.change(screen.getByPlaceholderText(/search tasks/i), {
+      target: { value: 'quick' },
+    })
+    const mark = screen.getByTestId('quick-search-highlight')
+    expect(mark.textContent).toBe('quick')
+    expect(mark.tagName).toBe('MARK')
+  })
+
+  it('shows empty state when no results match', () => {
+    render(<QuickSearch {...baseProps} open={true} onClose={vi.fn()} />)
+    fireEvent.change(screen.getByPlaceholderText(/search tasks/i), {
+      target: { value: 'nonexistent_xyz' },
+    })
+    expect(screen.getByText(/no tasks found/i)).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `QuickSearch` component — a command palette overlay triggered by **Cmd+K** (Mac) / **Ctrl+K** (Win/Linux)
- Searches all tasks (including DONE) by title (partial match) and task ID (prefix match), shows top 10 results with match highlighting
- Keyboard navigation (↑↓ arrows, Enter to open, Escape to close), click support, backdrop dismiss
- Opens TaskDetail panel on selection

## Acceptance Criteria

- [x] Cmd+K (Mac) / Ctrl+K (Win/Linux) opens search overlay
- [x] Search by title (partial match) and task_id (prefix match)
- [x] Top-10 results with match highlighting
- [x] Click or Enter opens TaskDetail
- [x] Escape closes overlay
- [x] Search works across all tasks including DONE
- [x] Tests: keyboard shortcut, search filtering, navigation, highlighting (14 tests)

## Test plan

- [x] `npx vitest run tests/client/quick-search.test.tsx` — 14 tests passing
- [x] `npx vitest run tests/client/` — all 167 tests passing
- [x] TypeScript: `npx tsc -p tsconfig.app.json --noEmit` — clean
- [x] ESLint: clean on changed files

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)