### PR TITLE
feat(#120): show last agent message on AWAITING_OWNER cards

### DIFF
--- a/server/api/tasks.js
+++ b/server/api/tasks.js
@@ -113,6 +113,21 @@ function readNDJSON(filePath) {
   })
 }
 
+/** Extract last agent (non-owner) comment text from events, truncated to 120 chars. */
+function extractLastAgentMessage(events) {
+  let last = null
+  for (const ev of events) {
+    const type = ev.event_type || ev.type
+    if (type === 'USER_COMMENT' && ev.actor && ev.actor !== 'owner') {
+      last = ev
+    }
+  }
+  if (!last) return null
+  const payload = last.payload || {}
+  const body = last.body || payload.body || ''
+  return body ? body.slice(0, 120) : null
+}
+
 /** Extract unique actors in chronological (first-seen) order from events array. */
 function extractActors(events) {
   const seen = new Set()
@@ -172,7 +187,8 @@ router.get('/', async (_req, res) => {
           const status = JSON.parse(readFileSync(join(TASKS_DIR, id, 'status.json'), 'utf8'))
           const events = await readNDJSON(join(TASKS_DIR, id, 'events.ndjson'))
           const actors = extractActors(events)
-          tasks.push({ task_id: id, contract, status, actors })
+          const lastAgentMessage = extractLastAgentMessage(events)
+          tasks.push({ task_id: id, contract, status, actors, lastAgentMessage })
         } catch { /* skip */ }
       }
     } catch { /* dir may not exist */ }

--- a/src/components/pipeline/TaskCard.tsx
+++ b/src/components/pipeline/TaskCard.tsx
@@ -128,6 +128,13 @@ export function TaskCard({ task, onClick, error }: TaskCardProps) {
             💬 Awaiting your input
           </div>
         )}
+
+        {/* Last agent message preview — AWAITING_OWNER only */}
+        {task.state === 'AWAITING_OWNER' && task.lastAgentMessage && (
+          <p className="text-xs text-text-secondary line-clamp-2 mt-1 border-l-2 border-amber pl-2">
+            {task.lastAgentMessage}
+          </p>
+        )}
       </div>
 
       {/* Inline error card for guard violations */}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -70,6 +70,7 @@ interface TaskListResponse {
     [key: string]: unknown;
   };
   actors?: string[];
+  lastAgentMessage?: string | null;
 }
 
 interface TaskDetailResponse extends TaskListResponse {
@@ -106,6 +107,7 @@ function toTask(item: TaskListResponse): Task {
     state_entered_at: s.updated_at || s.last_material_update || undefined,
     contract: c,
     actors: item.actors || [],
+    lastAgentMessage: item.lastAgentMessage ?? null,
   };
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -144,6 +144,7 @@ export interface Task {
   hasRelease: boolean;
   state_entered_at?: string;
   actors?: string[];
+  lastAgentMessage?: string | null;
   contract?: TaskContract;
   events?: TaskEvent[];
   decisions?: TaskDecision[];

--- a/tests/client/task-card-agent-message.test.tsx
+++ b/tests/client/task-card-agent-message.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen, cleanup } from '@testing-library/react'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import type { Task } from '../../src/lib/types'
+
+vi.mock('@dnd-kit/sortable', () => ({
+  useSortable: vi.fn(() => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: vi.fn(),
+    transform: null,
+    transition: null,
+    isDragging: false,
+  })),
+}))
+
+vi.mock('@dnd-kit/utilities', () => ({
+  CSS: { Transform: { toString: vi.fn(() => '') } },
+}))
+
+import { TaskCard } from '../../src/components/pipeline/TaskCard'
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: 'tsk_test',
+    state: 'AWAITING_OWNER',
+    owner: 'archimedes',
+    route: 'build_route',
+    title: 'Test task',
+    age: 30,
+    ttl: null,
+    blockers: 0,
+    retries: 0,
+    terminal: false,
+    hasQuality: false,
+    hasOutcome: false,
+    hasRelease: false,
+    actors: ['archimedes'],
+    ...overrides,
+  }
+}
+
+describe('TaskCard — lastAgentMessage preview', () => {
+  afterEach(cleanup)
+
+  it('renders agent message preview for AWAITING_OWNER with lastAgentMessage', () => {
+    const task = makeTask({ lastAgentMessage: 'I need clarification on the API schema' })
+    render(<TaskCard task={task} onClick={vi.fn()} />)
+
+    expect(screen.getByText('I need clarification on the API schema')).toBeInTheDocument()
+  })
+
+  it('does not render preview when lastAgentMessage is null', () => {
+    const task = makeTask({ lastAgentMessage: null })
+    render(<TaskCard task={task} onClick={vi.fn()} />)
+
+    // "Awaiting your input" should be present but no preview paragraph
+    expect(screen.getByText(/Awaiting your input/)).toBeInTheDocument()
+    expect(screen.queryByText('I need clarification')).not.toBeInTheDocument()
+  })
+
+  it('does not render preview for non-AWAITING_OWNER state even with lastAgentMessage', () => {
+    const task = makeTask({ state: 'EXECUTION', lastAgentMessage: 'Some message' })
+    render(<TaskCard task={task} onClick={vi.fn()} />)
+
+    expect(screen.queryByText('Some message')).not.toBeInTheDocument()
+  })
+
+  it('renders preview with border-l-2 and border-amber styling', () => {
+    const msg = 'Please review the failing test output'
+    const task = makeTask({ lastAgentMessage: msg })
+    render(<TaskCard task={task} onClick={vi.fn()} />)
+
+    const preview = screen.getByText(msg)
+    expect(preview.tagName).toBe('P')
+    expect(preview.className).toContain('border-l-2')
+    expect(preview.className).toContain('border-amber')
+    expect(preview.className).toContain('line-clamp-2')
+  })
+})


### PR DESCRIPTION
## Summary

- **Backend**: Extract `lastAgentMessage` from `events.ndjson` — last non-owner `USER_COMMENT` body, truncated to 120 chars — and include it in `GET /api/tasks` response
- **Frontend**: Render truncated agent message preview (`line-clamp-2`, amber `border-l-2`) on `AWAITING_OWNER` TaskCards, giving operators immediate context without opening TaskDetail
- **Test**: 4 tests covering render with message, no message (null), non-AWAITING state, and CSS classes

Closes #120

## Acceptance criteria

- [x] AWAITING_OWNER cards show truncated last agent message (max 2 lines)
- [x] No message → shows only 'Awaiting your input' (existing behavior)
- [x] Preview limited to 120 chars on backend, `line-clamp-2` on frontend
- [x] `GET /api/tasks` includes `lastAgentMessage` field
- [x] Test: TaskCard with `lastAgentMessage` renders preview

## Test plan

- [x] `npx vitest run` — all 211 tests pass (29 test files)
- [x] `npx tsc -p tsconfig.app.json --noEmit` — no type errors
- [ ] Manual: open Pipeline page, verify AWAITING_OWNER cards with agent comments show preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)