### PR TITLE
fix(#117): Add Event — inline textarea input

### DIFF
--- a/src/components/pipeline/TaskDetail.tsx
+++ b/src/components/pipeline/TaskDetail.tsx
@@ -19,6 +19,9 @@ export function TaskDetail({ task, onClose, onTransition }: TaskDetailProps) {
   const [loading, setLoading] = useState(true);
   const [transitionState, setTransitionState] = useState<import('../../lib/types').PipelineState | ''>('');
   const [actionError, setActionError] = useState<string | null>(null);
+  const [showEventInput, setShowEventInput] = useState(false);
+  const [eventText, setEventText] = useState('');
+  const [eventSubmitting, setEventSubmitting] = useState(false);
   const commentSectionRef = useRef<HTMLElement>(null);
 
   useEffect(() => {
@@ -68,16 +71,23 @@ export function TaskDetail({ task, onClose, onTransition }: TaskDetailProps) {
   }, [task.id, transitionState, onTransition]);
 
   const handleAddEvent = useCallback(async () => {
+    const body = eventText.trim();
+    if (!body || eventSubmitting) return;
     setActionError(null);
+    setEventSubmitting(true);
     try {
-      await addTaskEvent(task.id, 'NOTE', { actor: 'operator' });
+      await addTaskEvent(task.id, 'NOTE', { actor: 'operator', body });
       const evts = await fetchTaskEvents(task.id);
       setEvents(evts);
+      setEventText('');
+      setShowEventInput(false);
     } catch (e: unknown) {
       const err = e as { message?: string };
       setActionError(err.message || 'Failed to add event');
+    } finally {
+      setEventSubmitting(false);
     }
-  }, [task.id]);
+  }, [task.id, eventText, eventSubmitting]);
 
   // Subdirectories for artifacts
   const artifactDirs = ['issue-contracts', 'outputs', 'execution-bundles', 'review-findings'];
@@ -262,13 +272,32 @@ export function TaskDetail({ task, onClose, onTransition }: TaskDetailProps) {
                 </button>
               </div>
 
-              <div className="flex gap-2 mt-2">
+              <div className="mt-2">
                 <button
-                  onClick={handleAddEvent}
+                  onClick={() => setShowEventInput((v) => !v)}
                   className="px-3 py-1.5 rounded-sm border border-border-subtle text-text-secondary text-sm hover:bg-bg-elevated transition-colors"
                 >
-                  Add Event
+                  {showEventInput ? 'Cancel' : 'Add Event'}
                 </button>
+                {showEventInput && (
+                  <div className="flex gap-2 mt-2">
+                    <textarea
+                      className="flex-1 bg-bg-void border border-border-default rounded-sm p-2 text-sm text-text-primary placeholder:text-text-disabled resize-none focus:border-amber focus:outline-none disabled:opacity-50"
+                      rows={2}
+                      placeholder="Describe the event…"
+                      value={eventText}
+                      onChange={(e) => setEventText(e.target.value)}
+                      disabled={eventSubmitting}
+                    />
+                    <button
+                      onClick={handleAddEvent}
+                      disabled={!eventText.trim() || eventSubmitting}
+                      className="self-end px-3 py-1.5 rounded-sm bg-amber text-text-inverse font-semibold text-sm disabled:opacity-40 disabled:cursor-not-allowed hover:brightness-110 transition-all"
+                    >
+                      {eventSubmitting ? 'Adding…' : 'Add'}
+                    </button>
+                  </div>
+                )}
               </div>
             </section>
           </div>

--- a/tests/client/task-detail-add-event.test.tsx
+++ b/tests/client/task-detail-add-event.test.tsx
@@ -1,0 +1,149 @@
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
+
+// Mock useToast
+vi.mock('../../src/hooks/useToast', () => ({
+  useToast: () => ({ toasts: [], push: vi.fn(), dismiss: vi.fn(), dismissAll: vi.fn() }),
+}))
+
+// Mock api
+const mockAddTaskEvent = vi.fn()
+const mockFetchTaskEvents = vi.fn()
+vi.mock('../../src/lib/api', () => ({
+  addTaskEvent: (...args: unknown[]) => mockAddTaskEvent(...args),
+  fetchTaskEvents: (...args: unknown[]) => mockFetchTaskEvents(...args),
+  fetchTaskDecisions: vi.fn().mockResolvedValue([]),
+  fetchTaskContract: vi.fn().mockResolvedValue(null),
+  transitionTask: vi.fn(),
+}))
+
+import { TaskDetail } from '../../src/components/pipeline/TaskDetail'
+import type { Task } from '../../src/lib/types'
+
+const baseTask: Task = {
+  id: 'tsk_001',
+  state: 'EXECUTION',
+  owner: 'archimedes',
+  route: 'build_route',
+  title: 'Test Task',
+  age: 5,
+  ttl: null,
+  blockers: 0,
+  retries: 0,
+  terminal: false,
+  hasQuality: false,
+  hasOutcome: false,
+  hasRelease: false,
+  actors: [],
+}
+
+async function renderLoaded(taskOverrides?: Partial<Task>) {
+  const task = { ...baseTask, ...taskOverrides }
+  render(<TaskDetail task={task} onClose={vi.fn()} onTransition={vi.fn()} />)
+  // Wait for loading to finish (data fetches resolve)
+  await waitFor(() => {
+    expect(screen.queryByText('Loading...')).not.toBeInTheDocument()
+  })
+}
+
+describe('TaskDetail Add Event', () => {
+  afterEach(cleanup)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAddTaskEvent.mockResolvedValue({ ok: true })
+    mockFetchTaskEvents.mockResolvedValue([])
+  })
+
+  it('shows Add Event button but no textarea initially', async () => {
+    await renderLoaded()
+    expect(screen.getByRole('button', { name: /add event/i })).toBeInTheDocument()
+    expect(screen.queryByPlaceholderText(/describe the event/i)).not.toBeInTheDocument()
+  })
+
+  it('expands textarea on Add Event click', async () => {
+    await renderLoaded()
+    fireEvent.click(screen.getByRole('button', { name: /add event/i }))
+
+    expect(screen.getByPlaceholderText(/describe the event/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^add$/i })).toBeInTheDocument()
+    // Button text changes to Cancel
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument()
+  })
+
+  it('collapses textarea on Cancel click', async () => {
+    await renderLoaded()
+    fireEvent.click(screen.getByRole('button', { name: /add event/i }))
+    expect(screen.getByPlaceholderText(/describe the event/i)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(screen.queryByPlaceholderText(/describe the event/i)).not.toBeInTheDocument()
+  })
+
+  it('Add button is disabled when textarea is empty', async () => {
+    await renderLoaded()
+    fireEvent.click(screen.getByRole('button', { name: /add event/i }))
+
+    expect(screen.getByRole('button', { name: /^add$/i })).toBeDisabled()
+  })
+
+  it('Add button is disabled for whitespace-only input', async () => {
+    await renderLoaded()
+    fireEvent.click(screen.getByRole('button', { name: /add event/i }))
+
+    fireEvent.change(screen.getByPlaceholderText(/describe the event/i), {
+      target: { value: '   ' },
+    })
+    expect(screen.getByRole('button', { name: /^add$/i })).toBeDisabled()
+  })
+
+  it('submits event, hides textarea, and refreshes timeline', async () => {
+    const noteEvent = {
+      event_type: 'NOTE',
+      actor: 'operator',
+      timestamp: new Date().toISOString(),
+      payload: { body: 'Deploy completed' },
+    }
+    mockFetchTaskEvents.mockResolvedValueOnce([]).mockResolvedValueOnce([noteEvent])
+
+    await renderLoaded()
+    fireEvent.click(screen.getByRole('button', { name: /add event/i }))
+
+    const textarea = screen.getByPlaceholderText(/describe the event/i)
+    fireEvent.change(textarea, { target: { value: 'Deploy completed' } })
+    expect(screen.getByRole('button', { name: /^add$/i })).not.toBeDisabled()
+
+    fireEvent.click(screen.getByRole('button', { name: /^add$/i }))
+
+    await waitFor(() => {
+      expect(mockAddTaskEvent).toHaveBeenCalledWith('tsk_001', 'NOTE', {
+        actor: 'operator',
+        body: 'Deploy completed',
+      })
+    })
+
+    await waitFor(() => {
+      // Textarea should be hidden after successful submit
+      expect(screen.queryByPlaceholderText(/describe the event/i)).not.toBeInTheDocument()
+    })
+  })
+
+  it('shows error and keeps textarea open on failure', async () => {
+    mockAddTaskEvent.mockRejectedValue(new Error('Network error'))
+
+    await renderLoaded()
+    fireEvent.click(screen.getByRole('button', { name: /add event/i }))
+
+    fireEvent.change(screen.getByPlaceholderText(/describe the event/i), {
+      target: { value: 'Will fail' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /^add$/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Network error')).toBeInTheDocument()
+    })
+
+    // Textarea should still be visible
+    expect(screen.getByPlaceholderText(/describe the event/i)).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- Clicking "Add Event" now expands an inline textarea (no modal) with a placeholder
- Submit button is disabled when textarea is empty or whitespace-only
- On successful submit: textarea hides, event appears in timeline via re-fetch
- On error: error message displayed, textarea stays open for retry
- Button toggles between "Add Event" / "Cancel"

Closes #117

## Test plan
- [x] 7 new tests in `tests/client/task-detail-add-event.test.tsx`
  - expand/collapse toggle
  - disabled state for empty/whitespace input
  - submit flow with API call verification
  - error handling keeps textarea open
- [x] All 165 client tests pass
- [x] TypeScript and ESLint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)