### PR TITLE
feat(#137): move lastAgentMessage preview above CTA on AWAITING_OWNER cards

### DIFF
--- a/src/components/pipeline/TaskCard.tsx
+++ b/src/components/pipeline/TaskCard.tsx
@@ -137,18 +137,18 @@ export function TaskCard({ task, onClick, error }: TaskCardProps) {
           </div>
         </div>
 
-        {/* Awaiting Owner bar */}
-        {task.state === 'AWAITING_OWNER' && (
-          <div className="mt-2 px-2 py-1 rounded-sm bg-amber/10 text-amber text-xs font-medium">
-            💬 Awaiting your input
-          </div>
-        )}
-
         {/* Last agent message preview — AWAITING_OWNER only */}
         {task.state === 'AWAITING_OWNER' && task.lastAgentMessage && (
-          <p className="text-xs text-text-secondary line-clamp-2 mt-1 border-l-2 border-amber pl-2">
+          <p className="text-xs text-text-secondary line-clamp-2 mt-2 border-l-2 border-amber pl-2">
             {task.lastAgentMessage}
           </p>
+        )}
+
+        {/* Awaiting Owner bar */}
+        {task.state === 'AWAITING_OWNER' && (
+          <div className="mt-1 px-2 py-1 rounded-sm bg-amber/10 text-amber text-xs font-medium">
+            💬 Awaiting your input
+          </div>
         )}
       </div>
 


### PR DESCRIPTION
## Summary
- Swaps render order in `TaskCard.tsx` so the agent's last message (context) appears **above** the "💬 Awaiting your input" CTA bar on AWAITING_OWNER cards
- When `lastAgentMessage` is null, only the CTA renders — no layout change
- Adjusted margin classes to preserve spacing

Closes #137

## Test plan
- [ ] Verify AWAITING_OWNER card with `lastAgentMessage` shows preview above CTA
- [ ] Verify AWAITING_OWNER card without `lastAgentMessage` shows only the CTA (unchanged)
- [ ] CI green (lint + typecheck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)