### PR TITLE
fix(#136): PresetBar custom label — move to left of preset buttons

### DIFF
--- a/src/pages/Pipeline.tsx
+++ b/src/pages/Pipeline.tsx
@@ -84,6 +84,9 @@ function PresetBar({
 }) {
   return (
     <div className="flex items-center gap-2 px-3 pt-3 pb-1 bg-bg-surface">
+      {activePreset === null && (
+        <span className="text-xs text-text-disabled font-mono mr-1">custom</span>
+      )}
       {PRESETS.map((p) => (
         <button
           key={p.id}
@@ -97,9 +100,6 @@ function PresetBar({
           {p.label}
         </button>
       ))}
-      {activePreset === null && (
-        <span className="text-xs text-text-disabled font-mono ml-1">custom</span>
-      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Moved the `custom` label `<span>` before `{PRESETS.map(...)}` so it renders to the left of the preset buttons
- Changed `ml-1` → `mr-1` for correct spacing

Closes #136

## Test plan
- [ ] Verify `custom` label appears left of preset buttons when no preset is active
- [ ] Verify preset buttons still render and function correctly
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)