### PR TITLE
fix(#160): default Pipeline to All preset, hide empty on, DONE newest-first

### DIFF
--- a/src/components/pipeline/KanbanBoard.tsx
+++ b/src/components/pipeline/KanbanBoard.tsx
@@ -139,6 +139,24 @@ export function KanbanBoard({ tasks, onCardClick, onRefresh, loading, hideEmpty 
           return (a.age ?? Infinity) - (b.age ?? Infinity);
         });
       }
+      if (state === 'DONE') {
+        // Sort newest-first: use state_entered_at (best signal for completion
+        // time), then fall back to age ASC (lower age = more recent).
+        // If neither is available, sort by task id descending for determinism.
+        return filtered.sort((a, b) => {
+          const aAt = a.state_entered_at;
+          const bAt = b.state_entered_at;
+          if (aAt && bAt) return bAt.localeCompare(aAt); // DESC — newest first
+          if (aAt) return -1; // a has timestamp, b doesn't → a first
+          if (bAt) return 1;
+          // Fallback: age (lower = more recent → sort ASC to put recent first)
+          if (a.age != null && b.age != null) return a.age - b.age;
+          if (a.age != null) return -1;
+          if (b.age != null) return 1;
+          // Final deterministic fallback: id descending
+          return b.id.localeCompare(a.id);
+        });
+      }
       return filtered;
     },
     [tasks]

--- a/src/pages/Pipeline.tsx
+++ b/src/pages/Pipeline.tsx
@@ -55,13 +55,31 @@ const STORAGE_KEY = 'pipeline-filter-state';
 interface StoredFilterState {
   preset: PresetId | null;
   filters: Filters;
+  hideEmpty?: boolean;
+}
+
+/** Schema version for localStorage migration. Bump when defaults change. */
+const STORAGE_VERSION = 2;
+
+interface VersionedStoredState extends StoredFilterState {
+  version?: number;
 }
 
 function loadFilterState(): StoredFilterState | null {
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (!raw) return null;
-    return JSON.parse(raw);
+    const parsed: VersionedStoredState = JSON.parse(raw);
+
+    // Migrate: old versions (or missing version) that defaulted to active-only
+    // should be reset so the user gets the new "All" default instead of a
+    // silently persisted misleading active-only view.
+    if (!parsed.version || parsed.version < STORAGE_VERSION) {
+      localStorage.removeItem(STORAGE_KEY);
+      return null;
+    }
+
+    return parsed;
   } catch {
     return null;
   }
@@ -69,7 +87,8 @@ function loadFilterState(): StoredFilterState | null {
 
 function saveFilterState(state: StoredFilterState): void {
   try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+    const versioned: VersionedStoredState = { ...state, version: STORAGE_VERSION };
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(versioned));
   } catch { /* ignore */ }
 }
 
@@ -313,13 +332,13 @@ export default function Pipeline() {
   // Load initial filter state from localStorage
   const savedState = useRef(loadFilterState());
   const [filters, setFilters] = useState<Filters>(
-    savedState.current?.filters ?? { owners: [], route: '', stateGroup: 'active' }
+    savedState.current?.filters ?? { owners: [], route: '', stateGroup: 'all' }
   );
   const [activePreset, setActivePreset] = useState<PresetId | null>(
-    savedState.current?.preset ?? null
+    savedState.current !== null ? savedState.current.preset : 'all'
   );
 
-  const [hideEmpty, setHideEmpty] = useState(false);
+  const [hideEmpty, setHideEmpty] = useState(savedState.current ? savedState.current.hideEmpty ?? true : true);
   const [showSearch, setShowSearch] = useState(false);
   const [lastUpdated, setLastUpdated] = useState<number>(Date.now());
 
@@ -332,8 +351,8 @@ export default function Pipeline() {
 
   // Persist filter state to localStorage
   useEffect(() => {
-    saveFilterState({ preset: activePreset, filters });
-  }, [activePreset, filters]);
+    saveFilterState({ preset: activePreset, filters, hideEmpty });
+  }, [activePreset, filters, hideEmpty]);
 
   const handlePresetClick = useCallback((id: PresetId) => {
     const preset = PRESETS.find((p) => p.id === id)!;

--- a/tests/client/pipeline-all-done.test.tsx
+++ b/tests/client/pipeline-all-done.test.tsx
@@ -95,8 +95,8 @@ describe('Pipeline — all tasks DONE / empty active view regression', () => {
     })
 
     render(<Pipeline />)
-    // Default stateGroup is 'active', so all DONE tasks are filtered out → 0 / 3
-    expect(screen.getByText('0 / 3 tasks')).toBeInTheDocument()
+    // Default stateGroup is 'all' (issue #160), so all 3 DONE tasks are visible
+    expect(screen.getByText('3 tasks')).toBeInTheDocument()
   })
 
   it('All preset shows 3 tasks when all are DONE (no crash)', () => {

--- a/tests/client/pipeline-defaults.test.tsx
+++ b/tests/client/pipeline-defaults.test.tsx
@@ -1,0 +1,267 @@
+/**
+ * Tests for Pipeline page defaults (issue #160):
+ * - Fresh load defaults to preset "All"
+ * - Hide empty defaults to enabled
+ * - Old localStorage (version < 2) is migrated/ignored
+ * - DONE column sorts newest-first
+ */
+import { render, screen, cleanup } from '@testing-library/react'
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
+import type { Task, PipelineState } from '../../src/lib/types'
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+
+// Mock API calls
+vi.mock('../../src/lib/api', () => ({
+  fetchTasks: vi.fn(() => Promise.resolve([])),
+  createTask: vi.fn(),
+  fetchCurrentAgent: vi.fn(() => Promise.resolve({ id: 'archimedes' })),
+}))
+
+// Mock usePolling to return tasks synchronously
+const mockTasks: Task[] = []
+vi.mock('../../src/hooks/usePolling', () => ({
+  usePolling: vi.fn(() => ({
+    data: mockTasks,
+    loading: false,
+    refresh: vi.fn(),
+  })),
+}))
+
+// Mock dnd-kit
+vi.mock('@dnd-kit/core', () => ({
+  DndContext: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DragOverlay: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  closestCorners: vi.fn(),
+  KeyboardSensor: vi.fn(),
+  PointerSensor: vi.fn(),
+  useSensor: vi.fn(),
+  useSensors: vi.fn(() => []),
+  useDroppable: vi.fn(() => ({ setNodeRef: vi.fn(), isOver: false })),
+}))
+
+vi.mock('@dnd-kit/sortable', () => ({
+  SortableContext: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  verticalListSortingStrategy: {},
+  useSortable: vi.fn(() => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: vi.fn(),
+    transform: null,
+    transition: null,
+    isDragging: false,
+  })),
+}))
+
+vi.mock('@dnd-kit/utilities', () => ({
+  CSS: { Transform: { toString: () => undefined } },
+}))
+
+// Mock useToast
+vi.mock('../../src/hooks/useToast', () => ({
+  useToast: vi.fn(() => ({ push: vi.fn() })),
+}))
+
+import Pipeline from '../../src/pages/Pipeline'
+
+const STORAGE_KEY = 'pipeline-filter-state'
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: 'tsk_test',
+    state: 'EXECUTION' as PipelineState,
+    owner: 'archimedes',
+    route: 'build_route',
+    title: 'Test task',
+    age: 10,
+    ttl: null,
+    blockers: 0,
+    retries: 0,
+    terminal: false,
+    hasQuality: false,
+    hasOutcome: false,
+    hasRelease: false,
+    actors: [],
+    ...overrides,
+  }
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('Pipeline defaults (issue #160)', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    mockTasks.length = 0
+  })
+
+  afterEach(() => {
+    cleanup()
+    localStorage.clear()
+  })
+
+  it('defaults to "All" preset on fresh load (no localStorage)', () => {
+    render(<Pipeline />)
+    // The "All" button should have the active style (bg-amber)
+    const allBtn = screen.getByRole('button', { name: 'All' })
+    expect(allBtn.className).toContain('bg-amber')
+    // The "Active" button should NOT be active
+    const activeBtn = screen.getByRole('button', { name: 'Active' })
+    expect(activeBtn.className).not.toContain('bg-amber')
+  })
+
+  it('defaults to "All states" in the state group dropdown on fresh load', () => {
+    render(<Pipeline />)
+    // The state group select should show "all"
+    const stateSelect = screen.getByDisplayValue('All states')
+    expect(stateSelect).toBeTruthy()
+  })
+
+  it('defaults hideEmpty to true on fresh load', () => {
+    render(<Pipeline />)
+    const checkbox = screen.getByRole('checkbox')
+    expect(checkbox).toBeChecked()
+  })
+
+  it('migrates old localStorage (no version) to fresh defaults', () => {
+    // Simulate old persisted state with active-only default
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({
+      preset: 'active',
+      filters: { owners: [], route: '', stateGroup: 'active' },
+    }))
+
+    render(<Pipeline />)
+
+    // Should have reset to "All" preset, not kept old "Active"
+    const allBtn = screen.getByRole('button', { name: 'All' })
+    expect(allBtn.className).toContain('bg-amber')
+
+    // Old localStorage should have been cleared
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!)
+    expect(stored.version).toBe(2)
+    expect(stored.preset).toBe('all')
+  })
+
+  it('migrates old localStorage (version 1) to fresh defaults', () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({
+      version: 1,
+      preset: 'active',
+      filters: { owners: [], route: '', stateGroup: 'active' },
+    }))
+
+    render(<Pipeline />)
+    const allBtn = screen.getByRole('button', { name: 'All' })
+    expect(allBtn.className).toContain('bg-amber')
+  })
+
+  it('preserves valid version 2 localStorage state', () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({
+      version: 2,
+      preset: 'blocked',
+      filters: { owners: [], route: '', stateGroup: 'error' },
+      hideEmpty: false,
+    }))
+
+    render(<Pipeline />)
+    const blockedBtn = screen.getByRole('button', { name: 'Blocked' })
+    expect(blockedBtn.className).toContain('bg-amber')
+
+    // hideEmpty should be false as saved
+    const checkbox = screen.getByRole('checkbox')
+    expect(checkbox).not.toBeChecked()
+  })
+})
+
+// ─── DONE column sort tests ─────────────────────────────────────────────────
+
+describe('DONE column sorting — newest-first', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    mockTasks.length = 0
+  })
+
+  afterEach(() => {
+    cleanup()
+    localStorage.clear()
+  })
+
+  it('sorts DONE tasks by state_entered_at descending (newest first)', () => {
+    const oldDone = makeTask({
+      id: 'tsk_old',
+      state: 'DONE',
+      title: 'Old done',
+      terminal: true,
+      state_entered_at: '2026-01-01T00:00:00Z',
+    })
+    const newDone = makeTask({
+      id: 'tsk_new',
+      state: 'DONE',
+      title: 'New done',
+      terminal: true,
+      state_entered_at: '2026-03-15T00:00:00Z',
+    })
+    const midDone = makeTask({
+      id: 'tsk_mid',
+      state: 'DONE',
+      title: 'Mid done',
+      terminal: true,
+      state_entered_at: '2026-02-01T00:00:00Z',
+    })
+
+    mockTasks.push(oldDone, newDone, midDone)
+    render(<Pipeline />)
+
+    // All three DONE cards should render; check order
+    const cards = screen.getAllByText(/done/i).filter(el =>
+      el.textContent === 'New done' || el.textContent === 'Mid done' || el.textContent === 'Old done'
+    )
+    // The cards should appear in newest-first order
+    expect(cards.map(c => c.textContent)).toEqual(['New done', 'Mid done', 'Old done'])
+  })
+
+  it('falls back to age when state_entered_at is missing', () => {
+    const recentDone = makeTask({
+      id: 'tsk_recent',
+      state: 'DONE',
+      title: 'Recent by age',
+      terminal: true,
+      age: 5,
+    })
+    const olderDone = makeTask({
+      id: 'tsk_older',
+      state: 'DONE',
+      title: 'Older by age',
+      terminal: true,
+      age: 100,
+    })
+
+    mockTasks.push(olderDone, recentDone)
+    render(<Pipeline />)
+
+    const cards = screen.getAllByText(/by age/i)
+    expect(cards.map(c => c.textContent)).toEqual(['Recent by age', 'Older by age'])
+  })
+
+  it('uses deterministic id fallback when both timestamp and age are missing', () => {
+    const taskA = makeTask({
+      id: 'tsk_aaa',
+      state: 'DONE',
+      title: 'Task A',
+      terminal: true,
+      age: null,
+    })
+    const taskZ = makeTask({
+      id: 'tsk_zzz',
+      state: 'DONE',
+      title: 'Task Z',
+      terminal: true,
+      age: null,
+    })
+
+    mockTasks.push(taskA, taskZ)
+    render(<Pipeline />)
+
+    // id descending: tsk_zzz before tsk_aaa
+    const cards = screen.getAllByText(/Task [AZ]/)
+    expect(cards.map(c => c.textContent)).toEqual(['Task Z', 'Task A'])
+  })
+})

--- a/tests/client/pipeline-filtered-empty.test.tsx
+++ b/tests/client/pipeline-filtered-empty.test.tsx
@@ -11,6 +11,10 @@ import type { Task, PipelineState } from '../../src/lib/types'
  *  - one-click recovery action ("Show all tasks")
  *
  * True zero-data state must remain distinct.
+ *
+ * NOTE: As of #160 the default preset is "All" with Hide empty on,
+ * so filtered-empty only triggers after the user explicitly narrows
+ * the filter (e.g. switching to Active when all tasks are DONE).
  */
 
 // ─── DnD kit mocks ──────────────────────────────────────────────────────────
@@ -103,6 +107,11 @@ function mockPolling(data: Task[] | null, loading = false) {
   })
 }
 
+/** Switch the board to Active preset so only active states are shown. */
+function switchToActive() {
+  fireEvent.click(screen.getByRole('button', { name: 'Active' }))
+}
+
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
 describe('Pipeline — filtered-empty state (#148)', () => {
@@ -116,11 +125,25 @@ describe('Pipeline — filtered-empty state (#148)', () => {
     localStorage.clear()
   })
 
-  // ── All tasks DONE + default Active filter ─────────────────────────────
+  // ── Default is All (#160) — no filtered-empty on fresh load ───────────
 
-  it('shows filtered-empty state when all tasks are DONE and default filter is Active', () => {
+  it('does NOT show filtered-empty state on fresh load when all tasks are DONE (default=All, #160)', () => {
     mockPolling(allDoneTasks)
     render(<Pipeline />)
+
+    // Default is All — all DONE tasks are visible, no filtered-empty
+    expect(screen.queryByTestId('filtered-empty-state')).not.toBeInTheDocument()
+    expect(screen.getByText('3 tasks')).toBeInTheDocument()
+  })
+
+  // ── All tasks DONE + user switches to Active filter ───────────────────
+
+  it('shows filtered-empty state when user switches to Active and all tasks are DONE', () => {
+    mockPolling(allDoneTasks)
+    render(<Pipeline />)
+
+    // Switch to Active — all DONE tasks are hidden
+    switchToActive()
 
     const emptyState = screen.getByTestId('filtered-empty-state')
     expect(emptyState).toBeInTheDocument()
@@ -131,6 +154,7 @@ describe('Pipeline — filtered-empty state (#148)', () => {
   it('filtered-empty state includes "Show all tasks" recovery button', () => {
     mockPolling(allDoneTasks)
     render(<Pipeline />)
+    switchToActive()
 
     expect(screen.getByRole('button', { name: /show all tasks/i })).toBeInTheDocument()
   })
@@ -138,6 +162,7 @@ describe('Pipeline — filtered-empty state (#148)', () => {
   it('"Show all tasks" reveals hidden tasks', () => {
     mockPolling(allDoneTasks)
     render(<Pipeline />)
+    switchToActive()
 
     // Initially filtered-empty
     expect(screen.getByTestId('filtered-empty-state')).toBeInTheDocument()
@@ -155,6 +180,7 @@ describe('Pipeline — filtered-empty state (#148)', () => {
   it('"Show all tasks" sets the All preset as active', () => {
     mockPolling(allDoneTasks)
     render(<Pipeline />)
+    switchToActive()
 
     fireEvent.click(screen.getByRole('button', { name: /show all tasks/i }))
 
@@ -175,21 +201,21 @@ describe('Pipeline — filtered-empty state (#148)', () => {
 
   // ── Mixed dataset ──────────────────────────────────────────────────────
 
-  it('does NOT show filtered-empty state when some tasks match current filter', () => {
+  it('does NOT show filtered-empty state when all tasks match default All filter', () => {
     mockPolling(mixedTasks)
     render(<Pipeline />)
 
-    // Active filter shows 1 active task out of 3 — no filtered-empty state
+    // Default is All (#160) — all 3 tasks visible, no filtered-empty
     expect(screen.queryByTestId('filtered-empty-state')).not.toBeInTheDocument()
-    expect(screen.getByText('Active task tsk_a1')).toBeInTheDocument()
-    expect(screen.getByText('1 / 3 tasks')).toBeInTheDocument()
+    expect(screen.getByText('3 tasks')).toBeInTheDocument()
   })
 
-  // ── Persisted/default Active preset ────────────────────────────────────
+  // ── Persisted Active preset (version 2) ────────────────────────────────
 
-  it('shows filtered-empty state when persisted Active preset hides all tasks', () => {
-    // Simulate persisted Active preset in localStorage
+  it('shows filtered-empty state when persisted Active preset (v2) hides all tasks', () => {
+    // Simulate persisted Active preset in localStorage (version 2 required by #160)
     localStorage.setItem('pipeline-filter-state', JSON.stringify({
+      version: 2,
       preset: 'active',
       filters: { owners: [], route: '', stateGroup: 'active' },
     }))
@@ -200,8 +226,23 @@ describe('Pipeline — filtered-empty state (#148)', () => {
     expect(screen.getByText(/All 3 tasks are hidden/)).toBeInTheDocument()
   })
 
+  it('old localStorage (no version) is migrated to All default, no filtered-empty (#160)', () => {
+    // Old persisted Active preset without version — should be migrated/cleared
+    localStorage.setItem('pipeline-filter-state', JSON.stringify({
+      preset: 'active',
+      filters: { owners: [], route: '', stateGroup: 'active' },
+    }))
+    mockPolling(allDoneTasks)
+    render(<Pipeline />)
+
+    // Migration clears old state → defaults to All → no filtered-empty
+    expect(screen.queryByTestId('filtered-empty-state')).not.toBeInTheDocument()
+    expect(screen.getByText('3 tasks')).toBeInTheDocument()
+  })
+
   it('recovery works from persisted Active filter state', () => {
     localStorage.setItem('pipeline-filter-state', JSON.stringify({
+      version: 2,
       preset: 'active',
       filters: { owners: [], route: '', stateGroup: 'active' },
     }))
@@ -229,10 +270,10 @@ describe('Pipeline — filtered-empty state (#148)', () => {
     mockPolling(allDoneTasks)
     render(<Pipeline />)
 
-    // Start in filtered-empty (Active preset, all DONE)
-    expect(screen.getByTestId('filtered-empty-state')).toBeInTheDocument()
+    // Default is All — no filtered-empty yet
+    expect(screen.queryByTestId('filtered-empty-state')).not.toBeInTheDocument()
 
-    // Switch to Blocked preset — still no matching tasks
+    // Switch to Blocked preset — no matching tasks
     fireEvent.click(screen.getByRole('button', { name: 'Blocked' }))
     expect(screen.getByTestId('filtered-empty-state')).toBeInTheDocument()
     expect(screen.getByText(/All 3 tasks are hidden/)).toBeInTheDocument()
@@ -242,6 +283,8 @@ describe('Pipeline — filtered-empty state (#148)', () => {
     mockPolling(allDoneTasks)
     render(<Pipeline />)
 
+    // Switch to Active to trigger filtered-empty
+    switchToActive()
     expect(screen.getByTestId('filtered-empty-state')).toBeInTheDocument()
 
     // Click "All" preset button directly

--- a/tests/client/pipeline-page.test.tsx
+++ b/tests/client/pipeline-page.test.tsx
@@ -123,18 +123,17 @@ describe('Pipeline page (full Kanban)', () => {
     })
   })
 
-  it('defaults stateGroup to active on mount', () => {
+  it('defaults stateGroup to all on mount (issue #160)', () => {
     render(<Pipeline />)
-    // EXECUTION is an active state — should be visible
+    // All states visible with 'all' default
     expect(screen.getByText('EXECUTION')).toBeInTheDocument()
-    // Build feature X is in EXECUTION (active) — should be visible
     expect(screen.getByText('Build feature X')).toBeInTheDocument()
-    // DONE tasks should NOT appear with active default
-    expect(screen.queryByText('Deploy service Y')).not.toBeInTheDocument()
+    // DONE tasks should also appear with 'all' default
+    expect(screen.getByText('Deploy service Y')).toBeInTheDocument()
   })
 
   it('renders all columns when stateGroup is set to all via localStorage', () => {
-    localStorage.setItem('pipeline-filter-state', JSON.stringify({ preset: null, filters: { owners: [], route: '', stateGroup: 'all' } }))
+    localStorage.setItem('pipeline-filter-state', JSON.stringify({ version: 2, preset: null, filters: { owners: [], route: '', stateGroup: 'all' } }))
     render(<Pipeline />)
     expect(screen.getByText('EXECUTION')).toBeInTheDocument()
     expect(screen.getByText('DONE')).toBeInTheDocument()
@@ -142,7 +141,7 @@ describe('Pipeline page (full Kanban)', () => {
   })
 
   it('displays task cards in correct columns when stateGroup=all', () => {
-    localStorage.setItem('pipeline-filter-state', JSON.stringify({ preset: null, filters: { owners: [], route: '', stateGroup: 'all' } }))
+    localStorage.setItem('pipeline-filter-state', JSON.stringify({ version: 2, preset: null, filters: { owners: [], route: '', stateGroup: 'all' } }))
     render(<Pipeline />)
     expect(screen.getByText('Build feature X')).toBeInTheDocument()
     expect(screen.getByText('Deploy service Y')).toBeInTheDocument()
@@ -151,9 +150,10 @@ describe('Pipeline page (full Kanban)', () => {
 
   it('persists stateGroup selection to localStorage', () => {
     render(<Pipeline />)
-    // Default 'active' should be saved in pipeline-filter-state
+    // Default 'all' should be saved in pipeline-filter-state (issue #160)
     const stored = JSON.parse(localStorage.getItem('pipeline-filter-state')!)
-    expect(stored.filters.stateGroup).toBe('active')
+    expect(stored.filters.stateGroup).toBe('all')
+    expect(stored.version).toBe(2)
   })
 
   it('shows freshness indicator', () => {
@@ -166,26 +166,25 @@ describe('Pipeline page (full Kanban)', () => {
     expect(screen.getByRole('button', { name: /create task/i })).toBeInTheDocument()
   })
 
-  it('shows task count in header (active default)', () => {
+  it('shows task count in header (all default)', () => {
     render(<Pipeline />)
-    // Default stateGroup='active' → only EXECUTION (1/3 tasks)
-    expect(screen.getByText('1 / 3 tasks')).toBeInTheDocument()
+    // Default stateGroup='all' (issue #160) → all 3 tasks visible
+    expect(screen.getByText('3 tasks')).toBeInTheDocument()
   })
 
-  it('counter shows filtered/total when stateGroup filter is active', () => {
+  it('counter shows filtered/total when stateGroup filter is changed', () => {
     render(<Pipeline />)
-    // Default is 'active' — only EXECUTION (1/3 tasks)
-    expect(screen.getByText('1 / 3 tasks')).toBeInTheDocument()
-    // Change to 'all' — all 3 tasks visible
-    const stateSelect = screen.getByDisplayValue('Active')
-    fireEvent.change(stateSelect, { target: { value: 'all' } })
+    // Default is 'all' — all 3 tasks visible
     expect(screen.getByText('3 tasks')).toBeInTheDocument()
+    // Change to 'active' — only EXECUTION (1/3 tasks)
+    const stateSelect = screen.getByDisplayValue('All states')
+    fireEvent.change(stateSelect, { target: { value: 'active' } })
+    expect(screen.getByText('1 / 3 tasks')).toBeInTheDocument()
   })
 
   it('counter shows filtered/total when owner filter is active', async () => {
     const user = userEvent.setup()
-    // Use stateGroup=all so owner filter is the only active filter
-    localStorage.setItem('pipeline-filter-state', JSON.stringify({ preset: null, filters: { owners: [], route: '', stateGroup: 'all' } }))
+    // Default is stateGroup=all (issue #160)
     render(<Pipeline />)
     // All 3 tasks visible initially
     expect(screen.getByText('3 tasks')).toBeInTheDocument()
@@ -199,23 +198,26 @@ describe('Pipeline page (full Kanban)', () => {
 
   it('counter shows total when all filters are reset', () => {
     render(<Pipeline />)
-    // Start with active filter (default) — 1/3 tasks
+    // Default is 'all' (issue #160) — 3 tasks
+    expect(screen.getByText('3 tasks')).toBeInTheDocument()
+    // Switch to active — 1/3 tasks
+    const stateSelect = screen.getByDisplayValue('All states')
+    fireEvent.change(stateSelect, { target: { value: 'active' } })
     expect(screen.getByText('1 / 3 tasks')).toBeInTheDocument()
-    // Reset to 'all' — 3 tasks (no filter active)
-    const stateSelect = screen.getByDisplayValue('Active')
+    // Reset back to 'all' — 3 tasks
     fireEvent.change(stateSelect, { target: { value: 'all' } })
     expect(screen.getByText('3 tasks')).toBeInTheDocument()
   })
 
   it('counter updates when stateGroup changes', () => {
     render(<Pipeline />)
-    // Start at 'active' (default) — 1/3 tasks
-    const stateSelect = screen.getByDisplayValue('Active')
-    expect(screen.getByText('1 / 3 tasks')).toBeInTheDocument()
-
-    // All states: all 3 tasks
-    fireEvent.change(stateSelect, { target: { value: 'all' } })
+    // Start at 'all' (default, issue #160) — all 3 tasks
+    const stateSelect = screen.getByDisplayValue('All states')
     expect(screen.getByText('3 tasks')).toBeInTheDocument()
+
+    // Active: only EXECUTION (1 task)
+    fireEvent.change(stateSelect, { target: { value: 'active' } })
+    expect(screen.getByText('1 / 3 tasks')).toBeInTheDocument()
 
     // Terminal: only DONE (1 task)
     fireEvent.change(stateSelect, { target: { value: 'terminal' } })
@@ -252,8 +254,12 @@ describe('Pipeline page (full Kanban)', () => {
       refresh: vi.fn(),
     })
 
-    // Default is 'active' already — all tasks are DONE → 0/3
+    // Default is 'all' (issue #160) — all DONE tasks are visible → 3 tasks
     render(<Pipeline />)
+    expect(screen.getByText('3 tasks')).toBeInTheDocument()
+    // Switch to active — 0/3
+    const stateSelect = screen.getByDisplayValue('All states')
+    fireEvent.change(stateSelect, { target: { value: 'active' } })
     expect(screen.getByText('0 / 3 tasks')).toBeInTheDocument()
   })
 
@@ -263,17 +269,17 @@ describe('Pipeline page (full Kanban)', () => {
     expect(screen.getByTestId('multi-select-trigger')).toHaveTextContent('All owners')
   })
 
-  it('shows hide empty checkbox in filter bar (not header)', () => {
+  it('shows hide empty checkbox in filter bar (checked by default, issue #160)', () => {
     render(<Pipeline />)
     const hideEmptyCheckbox = screen.getByRole('checkbox', { name: /hide empty/i })
     expect(hideEmptyCheckbox).toBeInTheDocument()
-    // Should be unchecked by default
-    expect(hideEmptyCheckbox).not.toBeChecked()
+    // Should be checked by default (issue #160)
+    expect(hideEmptyCheckbox).toBeChecked()
   })
 
   it('multi-owner filter shows tasks from all selected owners', async () => {
     const user = userEvent.setup()
-    localStorage.setItem('pipeline-filter-state', JSON.stringify({ preset: null, filters: { owners: [], route: '', stateGroup: 'all' } }))
+    // Default is already stateGroup=all (issue #160), no localStorage needed
     render(<Pipeline />)
 
     // Open multi-select dropdown

--- a/tests/client/pipeline-presets.test.tsx
+++ b/tests/client/pipeline-presets.test.tsx
@@ -176,8 +176,9 @@ describe('Pipeline presets & localStorage', () => {
   })
 
   it('restores custom filters from localStorage', () => {
-    // Pre-seed localStorage with custom filter state
+    // Pre-seed localStorage with custom filter state (version 2 required for migration, issue #160)
     const customState = {
+      version: 2,
       preset: null,
       filters: { owners: ['archimedes'], route: '', stateGroup: 'all' as const },
     }


### PR DESCRIPTION
## Summary

Fixes the Pipeline board defaults per operator feedback (issue #160):

- **Default preset → `All`** instead of implicit active-only view
- **`Hide empty` → enabled by default** on fresh load
- **localStorage migration**: old versions (pre-v2) are cleared so stale active-only defaults don't silently persist
- **DONE column sorts newest-first** using `state_entered_at`, with deterministic fallbacks to `age` then `id`
- `hideEmpty` state is now persisted in localStorage alongside filters

## Changes

- `src/pages/Pipeline.tsx`: New versioned localStorage schema (v2), migration logic, updated defaults
- `src/components/pipeline/KanbanBoard.tsx`: DONE column sort comparator (newest-first)
- `tests/client/pipeline-defaults.test.tsx`: 9 new tests covering fresh load, migration, DONE sorting
- Updated 3 existing test files to reflect new defaults

## Test plan

- [x] Fresh load defaults to `All` preset with `Hide empty` checked
- [x] Old localStorage (no version or version < 2) is cleared → falls back to new defaults
- [x] Valid v2 localStorage is preserved (e.g. user-chosen `Blocked` preset)
- [x] DONE column sorts by `state_entered_at` DESC, then `age` ASC, then `id` DESC
- [x] All 347 tests pass, lint and typecheck clean

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)