### PR TITLE
feat(#159): enrich task cards/detail with source, goal, and next action

### DIFF
--- a/server/api/tasks.js
+++ b/server/api/tasks.js
@@ -85,11 +85,17 @@ async function getGitHubTasks() {
 
       tasks.push({
         task_id: `gh-${pid}-${issue.number}`,
-        contract: { title: issue.title, route: 'build_route', outcome_type: 'app_release' },
+        contract: {
+          title: issue.title, route: 'build_route', outcome_type: 'app_release',
+          raw_request: issue.title,
+          source_ref: { repo: repos[ri], issue_number: issue.number },
+        },
         status: { state, current_owner: owner, current_route: 'build_route',
           blockers: [], retries: 0, updated_at: issue.closedAt || issue.createdAt,
-          last_material_update: issue.closedAt || issue.createdAt },
+          last_material_update: issue.closedAt || issue.createdAt,
+          next_action: session?.status ? `AO session: ${session.status}` : null },
         actors: session ? ['platon', 'archimedes'] : ['platon'],
+        source_type: 'github',
       })
     }
   }
@@ -205,7 +211,7 @@ router.get('/', async (_req, res) => {
           const events = await readNDJSON(join(TASKS_DIR, id, 'events.ndjson'))
           const actors = extractActors(events)
           const lastAgentMessage = extractLastAgentMessage(events)
-          tasks.push({ task_id: id, contract, status, actors, lastAgentMessage })
+          tasks.push({ task_id: id, contract, status, actors, lastAgentMessage, source_type: 'ledger' })
         } catch { /* skip */ }
       }
     } catch { /* dir may not exist */ }
@@ -241,7 +247,7 @@ router.get('/:id', async (req, res) => {
     ])
     const actors = extractActors(events)
 
-    res.json({ task_id: id, contract, status, events, decisions, actors })
+    res.json({ task_id: id, contract, status, events, decisions, actors, source_type: 'ledger' })
   } catch (e) {
     res.status(500).json({ ok: false, error: 'INTERNAL', detail: e.message })
   }

--- a/src/components/pipeline/OperatorSummary.tsx
+++ b/src/components/pipeline/OperatorSummary.tsx
@@ -1,0 +1,106 @@
+import { useState } from 'react';
+import type { Task, TaskContract } from '../../lib/types';
+
+interface OperatorSummaryProps {
+  task: Task;
+  contract: TaskContract | null;
+}
+
+const TRUNCATE_LEN = 120;
+
+function SourceBadge({ task }: { task: Task }) {
+  if (task.source_type === 'github' && task.source_ref) {
+    return (
+      <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-sm bg-bg-elevated text-text-secondary text-xs font-mono">
+        <span aria-hidden>GH</span>
+        {task.source_ref.repo}#{task.source_ref.issue_number}
+      </span>
+    );
+  }
+  if (task.source_type === 'github') {
+    return (
+      <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-sm bg-bg-elevated text-text-secondary text-xs font-mono">
+        GitHub issue
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-sm bg-bg-elevated text-text-secondary text-xs font-mono">
+      Ledger task
+    </span>
+  );
+}
+
+function TruncatedText({ text, testId }: { text: string; testId?: string }) {
+  const [expanded, setExpanded] = useState(false);
+  const needsTruncation = text.length > TRUNCATE_LEN;
+
+  return (
+    <span data-testid={testId}>
+      <span className="text-sm text-text-primary">
+        {expanded || !needsTruncation ? text : text.slice(0, TRUNCATE_LEN) + '...'}
+      </span>
+      {needsTruncation && (
+        <button
+          onClick={() => setExpanded((v) => !v)}
+          className="ml-1 text-xs text-amber hover:underline"
+          data-testid={testId ? `${testId}-toggle` : undefined}
+        >
+          {expanded ? 'less' : 'more'}
+        </button>
+      )}
+    </span>
+  );
+}
+
+export function OperatorSummary({ task, contract }: OperatorSummaryProps) {
+  const goal = task.goal
+    || (contract?.success_definition && contract.success_definition.length > 0
+      ? contract.success_definition[0]
+      : null)
+    || contract?.raw_request
+    || null;
+
+  const nextAction = task.next_action || null;
+
+  return (
+    <section data-testid="operator-summary">
+      <h3 className="text-sm font-semibold text-text-secondary uppercase tracking-wider mb-2">
+        Summary
+      </h3>
+      <div className="space-y-2">
+        {/* Source / Provenance */}
+        <div className="flex items-start gap-2">
+          <span className="text-xs text-text-tertiary w-16 shrink-0 pt-0.5">Source</span>
+          <SourceBadge task={task} />
+        </div>
+
+        {/* Goal / Outcome */}
+        <div className="flex items-start gap-2">
+          <span className="text-xs text-text-tertiary w-16 shrink-0 pt-0.5">Goal</span>
+          {goal ? (
+            <TruncatedText text={goal} testId="goal-text" />
+          ) : (
+            <span className="text-sm text-text-disabled italic" data-testid="goal-fallback">Not specified</span>
+          )}
+        </div>
+
+        {/* Next Action */}
+        <div className="flex items-start gap-2">
+          <span className="text-xs text-text-tertiary w-16 shrink-0 pt-0.5">Next</span>
+          {nextAction ? (
+            <TruncatedText text={nextAction} testId="next-action-text" />
+          ) : (
+            <span className="text-sm text-text-disabled italic" data-testid="next-action-fallback">No next action recorded</span>
+          )}
+        </div>
+
+        {/* Owner */}
+        <div className="flex items-start gap-2">
+          <span className="text-xs text-text-tertiary w-16 shrink-0 pt-0.5">Owner</span>
+          <span className="text-sm font-mono text-text-primary">{task.owner || 'Unassigned'}</span>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/pipeline/TaskCard.tsx
+++ b/src/components/pipeline/TaskCard.tsx
@@ -104,6 +104,25 @@ export function TaskCard({ task, onClick, error }: TaskCardProps) {
           })()}
         </div>
 
+        {/* Context cue: source + goal/next-action snippet */}
+        <div className="flex items-center gap-1.5 mt-1.5">
+          {task.source_type === 'github' ? (
+            <span className="inline-flex items-center px-1 py-0.5 rounded-sm bg-bg-elevated text-text-tertiary text-[10px] font-mono" title="GitHub issue">
+              GH
+            </span>
+          ) : (
+            <span className="inline-flex items-center px-1 py-0.5 rounded-sm bg-bg-elevated text-text-tertiary text-[10px] font-mono" title="Ledger task">
+              LDG
+            </span>
+          )}
+          {(task.goal || task.next_action) && (
+            <span className="text-xs text-text-tertiary truncate" title={task.goal || task.next_action || undefined}>
+              {(task.goal || task.next_action || '').slice(0, 60)}
+              {(task.goal || task.next_action || '').length > 60 ? '...' : ''}
+            </span>
+          )}
+        </div>
+
         {/* Indicators row */}
         <div className="flex items-center gap-2 mt-2">
           {/* Blockers */}

--- a/src/components/pipeline/TaskDetail.tsx
+++ b/src/components/pipeline/TaskDetail.tsx
@@ -6,6 +6,7 @@ import { EventTimeline } from './EventTimeline';
 import { CommentThread } from './CommentThread';
 import { CommentInput } from './CommentInput';
 import FlowStrip from './FlowStrip';
+import { OperatorSummary } from './OperatorSummary';
 
 interface TaskDetailProps {
   task: Task;
@@ -131,6 +132,9 @@ export function TaskDetail({ task, onClose, onTransition }: TaskDetailProps) {
           <div className="p-4 text-text-secondary text-sm">Loading...</div>
         ) : (
           <div className="p-4 space-y-6">
+            {/* Operator Summary */}
+            <OperatorSummary task={task} contract={contract} />
+
             {/* Actor Flow */}
             {(task.actors && task.actors.length > 0 || task.owner) && (
               <section>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -68,10 +68,12 @@ interface TaskListResponse {
     retries?: number;
     updated_at?: string;
     last_material_update?: string;
+    next_action?: string | null;
     [key: string]: unknown;
   };
   actors?: string[];
   lastAgentMessage?: string | null;
+  source_type?: 'ledger' | 'github';
 }
 
 interface TaskDetailResponse extends TaskListResponse {
@@ -86,6 +88,14 @@ const TERMINAL = ['DONE', 'FAILED', 'CANCELLED', 'SUPERSEDED'];
 function minutesAgo(iso?: string | null): number | null {
   if (!iso) return null;
   return Math.floor((Date.now() - new Date(iso).getTime()) / 60000);
+}
+
+function deriveGoal(c: TaskContract | undefined): string | null {
+  if (!c) return null;
+  const defs = c.success_definition;
+  if (defs && defs.length > 0) return defs[0].slice(0, 200);
+  if (c.raw_request) return c.raw_request.slice(0, 200);
+  return null;
 }
 
 function toTask(item: TaskListResponse): Task {
@@ -109,6 +119,10 @@ function toTask(item: TaskListResponse): Task {
     contract: c,
     actors: item.actors || [],
     lastAgentMessage: item.lastAgentMessage ?? null,
+    source_type: item.source_type ?? (c?.source_ref ? 'github' : 'ledger'),
+    source_ref: c?.source_ref,
+    next_action: s.next_action ?? null,
+    goal: deriveGoal(c),
   };
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -114,6 +114,11 @@ export interface TaskDecision {
   summary: string;
 }
 
+export interface TaskSourceRef {
+  repo: string;
+  issue_number: number;
+}
+
 export interface TaskContract {
   schema_version: string;
   task_id: string;
@@ -125,6 +130,8 @@ export interface TaskContract {
   full_solution: boolean;
   approval_policy: string;
   constraints: string[];
+  success_definition?: string[];
+  source_ref?: TaskSourceRef;
   created_at: string;
 }
 
@@ -145,6 +152,10 @@ export interface Task {
   state_entered_at?: string;
   actors?: string[];
   lastAgentMessage?: string | null;
+  source_type?: 'ledger' | 'github';
+  source_ref?: TaskSourceRef;
+  next_action?: string | null;
+  goal?: string | null;
   contract?: TaskContract;
   events?: TaskEvent[];
   decisions?: TaskDecision[];

--- a/tests/client/task-context-enrichment.test.tsx
+++ b/tests/client/task-context-enrichment.test.tsx
@@ -1,0 +1,225 @@
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import type { Task, TaskContract } from '../../src/lib/types';
+
+// ── dnd-kit mocks (required by TaskCard) ──────────────────────────────────────
+
+vi.mock('@dnd-kit/sortable', () => ({
+  useSortable: vi.fn(() => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: vi.fn(),
+    transform: null,
+    transition: null,
+    isDragging: false,
+  })),
+}));
+
+vi.mock('@dnd-kit/utilities', () => ({
+  CSS: { Transform: { toString: vi.fn(() => '') } },
+}));
+
+// ── Lazy imports (after mocks) ────────────────────────────────────────────────
+
+import { TaskCard } from '../../src/components/pipeline/TaskCard';
+import { OperatorSummary } from '../../src/components/pipeline/OperatorSummary';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: 'tsk_test_001',
+    state: 'EXECUTION',
+    owner: 'archimedes',
+    route: 'build_route',
+    title: 'Test task',
+    age: 30,
+    ttl: null,
+    blockers: 0,
+    retries: 0,
+    terminal: false,
+    hasQuality: false,
+    hasOutcome: false,
+    hasRelease: false,
+    ...overrides,
+  };
+}
+
+function makeContract(overrides: Partial<TaskContract> = {}): TaskContract {
+  return {
+    schema_version: '1.0',
+    task_id: 'tsk_test_001',
+    title: 'Test task',
+    raw_request: 'Build the feature as described',
+    outcome_type: 'app_release',
+    delivery_mode: 'repo_build',
+    route: 'build_route',
+    full_solution: true,
+    approval_policy: 'delegated_timeout',
+    constraints: [],
+    created_at: '2026-04-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+const noop = vi.fn();
+
+// ── OperatorSummary tests ─────────────────────────────────────────────────────
+
+describe('OperatorSummary', () => {
+  afterEach(cleanup);
+
+  it('renders ledger task with rich contract fields', () => {
+    const task = makeTask({
+      source_type: 'ledger',
+      goal: 'Ship the dashboard v2',
+      next_action: 'Merge PR #42 after CI passes',
+    });
+    const contract = makeContract({
+      success_definition: ['All AC checkboxes green'],
+    });
+
+    render(<OperatorSummary task={task} contract={contract} />);
+
+    expect(screen.getByTestId('operator-summary')).toBeTruthy();
+    expect(screen.getByText('Ledger task')).toBeTruthy();
+    expect(screen.getByText('Ship the dashboard v2')).toBeTruthy();
+    expect(screen.getByText('Merge PR #42 after CI passes')).toBeTruthy();
+  });
+
+  it('renders GitHub-synthesized task with repo/issue provenance', () => {
+    const task = makeTask({
+      source_type: 'github',
+      source_ref: { repo: 'aerbaser/ao-dashboard', issue_number: 159 },
+      goal: 'Enrich task cards',
+      next_action: null,
+    });
+
+    render(<OperatorSummary task={task} contract={null} />);
+
+    expect(screen.getByText(/aerbaser\/ao-dashboard#159/)).toBeTruthy();
+    expect(screen.getByText('Enrich task cards')).toBeTruthy();
+    expect(screen.getByTestId('next-action-fallback')).toBeTruthy();
+    expect(screen.getByText('No next action recorded')).toBeTruthy();
+  });
+
+  it('shows fallback labels when raw_request and goal are missing', () => {
+    const task = makeTask({ source_type: 'ledger', goal: null, next_action: null });
+    const contract = makeContract({ raw_request: '', success_definition: [] });
+
+    render(<OperatorSummary task={task} contract={contract} />);
+
+    expect(screen.getByTestId('goal-fallback')).toBeTruthy();
+    expect(screen.getByText('Not specified')).toBeTruthy();
+    expect(screen.getByTestId('next-action-fallback')).toBeTruthy();
+  });
+
+  it('falls back to raw_request when success_definition is empty', () => {
+    const task = makeTask({ source_type: 'ledger', goal: null, next_action: null });
+    const contract = makeContract({
+      raw_request: 'Fix the login bug',
+      success_definition: [],
+    });
+
+    render(<OperatorSummary task={task} contract={contract} />);
+
+    expect(screen.getByText('Fix the login bug')).toBeTruthy();
+  });
+
+  it('truncates long text with expand/collapse toggle', () => {
+    const longGoal = 'A'.repeat(200);
+    const task = makeTask({ goal: longGoal });
+    const contract = makeContract();
+
+    render(<OperatorSummary task={task} contract={contract} />);
+
+    // Should show truncated version (120 chars + "...")
+    const goalEl = screen.getByTestId('goal-text');
+    expect(goalEl.textContent).toContain('...');
+    expect(goalEl.textContent).toContain('more');
+
+    // Click expand
+    fireEvent.click(screen.getByTestId('goal-text-toggle'));
+    expect(goalEl.textContent).toContain(longGoal);
+    expect(goalEl.textContent).toContain('less');
+
+    // Click collapse
+    fireEvent.click(screen.getByTestId('goal-text-toggle'));
+    expect(goalEl.textContent).toContain('...');
+  });
+
+  it('renders without crash when contract is null (no events, no decisions)', () => {
+    const task = makeTask({ source_type: 'ledger', goal: null, next_action: null });
+
+    render(<OperatorSummary task={task} contract={null} />);
+
+    expect(screen.getByTestId('operator-summary')).toBeTruthy();
+    expect(screen.getByText('Not specified')).toBeTruthy();
+    expect(screen.getByText('No next action recorded')).toBeTruthy();
+  });
+
+  it('shows GitHub source without source_ref gracefully', () => {
+    const task = makeTask({ source_type: 'github', goal: 'Do something' });
+
+    render(<OperatorSummary task={task} contract={null} />);
+
+    expect(screen.getByText('GitHub issue')).toBeTruthy();
+  });
+});
+
+// ── TaskCard context cue tests ────────────────────────────────────────────────
+
+describe('TaskCard context cues', () => {
+  afterEach(cleanup);
+
+  it('shows LDG badge for ledger tasks', () => {
+    const task = makeTask({ source_type: 'ledger', goal: 'Ship feature' });
+
+    render(<TaskCard task={task} onClick={noop} />);
+
+    expect(screen.getByText('LDG')).toBeTruthy();
+    expect(screen.getByText(/Ship feature/)).toBeTruthy();
+  });
+
+  it('shows GH badge for GitHub tasks', () => {
+    const task = makeTask({ source_type: 'github', goal: 'Fix issue' });
+
+    render(<TaskCard task={task} onClick={noop} />);
+
+    expect(screen.getByText('GH')).toBeTruthy();
+  });
+
+  it('shows next_action when goal is missing', () => {
+    const task = makeTask({ goal: null, next_action: 'Review PR #10' });
+
+    render(<TaskCard task={task} onClick={noop} />);
+
+    expect(screen.getByText(/Review PR #10/)).toBeTruthy();
+  });
+
+  it('truncates long goal text at 60 chars on card', () => {
+    const longGoal = 'B'.repeat(80);
+    const task = makeTask({ goal: longGoal });
+
+    render(<TaskCard task={task} onClick={noop} />);
+
+    const snippetEl = screen.getByText(/B{10,}\.{3}/);
+    expect(snippetEl).toBeTruthy();
+  });
+
+  it('does not show snippet when both goal and next_action are missing', () => {
+    const task = makeTask({ goal: null, next_action: null });
+
+    const { container } = render(<TaskCard task={task} onClick={noop} />);
+
+    // Should still show the source badge
+    expect(screen.getByText('LDG')).toBeTruthy();
+    // No snippet text beyond the badge
+    const contextRow = container.querySelectorAll('.truncate');
+    // Title has truncate too, so just confirm no extra snippet content
+    const snippets = Array.from(contextRow).filter(
+      (el) => el.textContent && el.textContent.length > 0 && !el.textContent.includes('Test task')
+    );
+    expect(snippets.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Add **OperatorSummary** section to TaskDetail showing source/provenance, goal/outcome, next action, and owner — operators no longer need to infer context from raw event timeline
- TaskCard now shows **source type badge** (LDG for ledger, GH for GitHub) and a compact **goal/next-action snippet** without adding clutter
- Backend exposes `source_type` (`ledger` | `github`) and `source_ref` (repo + issue number) for GitHub-synthesized tasks
- Graceful fallbacks: "Not specified" for missing goal, "No next action recorded" for missing next_action
- Long text truncation with expand/collapse toggle in detail panel

## Test plan

- [x] 12 new tests in `tests/client/task-context-enrichment.test.tsx`
- [x] Covers: ledger task with rich contract, GitHub-synthesized task, missing raw_request, null contract, long text truncation, card badges, fallback labels
- [x] Full suite passes (350 tests, 47 files)
- [x] TypeScript typecheck clean
- [x] ESLint clean on all changed files

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)