### PR TITLE
feat(#164): approval queue with Yes/Later/No/Rescope decision cards

### DIFF
--- a/server/api/ideas.js
+++ b/server/api/ideas.js
@@ -11,7 +11,8 @@ const IDEAS_DIR = join(HOME, 'clawd/ideas')
 const SESSIONS_SEND = join(HOME, 'clawd/scripts/sessions-send.js')
 const MAILBOXES_DIR = join(HOME, 'clawd/runtime/mailboxes')
 
-const VALID_STATUSES = ['draft', 'brainstorming', 'artifact_ready', 'approved', 'in_work', 'archived']
+const VALID_STATUSES = ['draft', 'brainstorming', 'artifact_ready', 'pending_approval', 'approved', 'in_work', 'archived']
+const VALID_DECISION_ACTIONS = ['yes', 'later', 'no', 'rescope']
 const VALID_AGENTS = ['brainstorm-claude', 'brainstorm-codex', 'sokrat']
 const VALID_ID_RE = /^idea_\d{8}_[a-f0-9]{6}$/
 
@@ -139,10 +140,37 @@ router.post('/:id/approve', async (req, res) => {
 
     existing.status = 'approved'
     existing.updated_at = new Date().toISOString()
+    existing.pending_since = null
 
     if (req.body.task_id) {
       existing.task_id = req.body.task_id
     }
+
+    await writeFile(filePath, JSON.stringify(existing, null, 2))
+    res.json(existing)
+  } catch (err) {
+    res.status(500).json({ error: err.message })
+  }
+})
+
+// POST /api/ideas/:id/submit-for-approval — transition artifact_ready → pending_approval
+router.post('/:id/submit-for-approval', async (req, res) => {
+  if (!validateId(req, res)) return
+  try {
+    const filePath = join(IDEAS_DIR, `${req.params.id}.json`)
+    const existing = await safeReadJson(filePath)
+    if (!existing) {
+      return res.status(404).json({ error: 'idea not found' })
+    }
+
+    if (existing.status !== 'artifact_ready') {
+      return res.status(400).json({ error: `Cannot submit for approval: status is "${existing.status}", expected "artifact_ready"` })
+    }
+
+    const now = new Date().toISOString()
+    existing.status = 'pending_approval'
+    existing.pending_since = now
+    existing.updated_at = now
 
     await writeFile(filePath, JSON.stringify(existing, null, 2))
     res.json(existing)
@@ -165,6 +193,68 @@ router.delete('/:id', async (req, res) => {
     existing.updated_at = new Date().toISOString()
     await writeFile(filePath, JSON.stringify(existing, null, 2))
     res.json(existing)
+  } catch (err) {
+    res.status(500).json({ error: err.message })
+  }
+})
+
+// POST /api/ideas/:id/decision — record an approval decision (yes/later/no/rescope)
+router.post('/:id/decision', async (req, res) => {
+  if (!validateId(req, res)) return
+  try {
+    const filePath = join(IDEAS_DIR, `${req.params.id}.json`)
+    const existing = await safeReadJson(filePath)
+    if (!existing) {
+      return res.status(404).json({ error: 'idea not found' })
+    }
+
+    if (existing.status !== 'pending_approval') {
+      return res.status(409).json({
+        error: 'STALE_STATE',
+        message: `Idea is "${existing.status}", not pending_approval — it may have been resolved elsewhere`,
+        current_status: existing.status,
+      })
+    }
+
+    const { action, reason } = req.body
+    if (!action || !VALID_DECISION_ACTIONS.includes(action)) {
+      return res.status(400).json({ error: `Invalid action: ${action}. Must be one of: ${VALID_DECISION_ACTIONS.join(', ')}` })
+    }
+
+    const now = new Date().toISOString()
+    const decision = {
+      action,
+      actor: 'platon',
+      timestamp: now,
+      reason: reason || undefined,
+    }
+
+    // Append to decisions log
+    if (!Array.isArray(existing.approval_decisions)) {
+      existing.approval_decisions = []
+    }
+    existing.approval_decisions.push(decision)
+    existing.updated_at = now
+
+    // Transition based on action
+    switch (action) {
+      case 'yes':
+        existing.status = 'approved'
+        break
+      case 'later':
+        // Stay pending_approval — no status change
+        break
+      case 'no':
+        existing.status = 'archived'
+        break
+      case 'rescope':
+        existing.status = 'draft'
+        existing.pending_since = null
+        break
+    }
+
+    await writeFile(filePath, JSON.stringify(existing, null, 2))
+    res.json({ ok: true, idea: existing, decision })
   } catch (err) {
     res.status(500).json({ error: err.message })
   }

--- a/server/lib/status.js
+++ b/server/lib/status.js
@@ -156,21 +156,23 @@ async function getUsagePercents() {
 
 // ── Ideas actionable count ───────────────────────────────────────────────
 
-async function getIdeasActionableCount() {
+async function getIdeasCounts() {
   try {
     const files = await readdir(IDEAS_DIR)
     const jsonFiles = files.filter(f => f.endsWith('.json'))
-    let count = 0
+    let actionable = 0
+    let pendingApproval = 0
     for (const f of jsonFiles) {
       try {
         const raw = await readFile(join(IDEAS_DIR, f), 'utf8')
         const idea = JSON.parse(raw)
-        if (idea.status === 'draft' || idea.status === 'artifact_ready') count++
+        if (idea.status === 'draft' || idea.status === 'artifact_ready') actionable++
+        if (idea.status === 'pending_approval') pendingApproval++
       } catch { /* skip malformed */ }
     }
-    return count
+    return { ideas_actionable: actionable, approvals_pending: pendingApproval }
   } catch {
-    return 0
+    return { ideas_actionable: 0, approvals_pending: 0 }
   }
 }
 
@@ -178,13 +180,13 @@ async function getIdeasActionableCount() {
 
 export async function getGlobalStatus() {
   // Run all independent reads in parallel
-  const [heartbeats, taskCounts, services, usage, vitals, ideasActionable] = await Promise.all([
+  const [heartbeats, taskCounts, services, usage, vitals, ideasCounts] = await Promise.all([
     getHeartbeats(),
     getTaskCounts(),
     fetchServices(),
     getUsagePercents(),
     Promise.resolve(getVitals()),
-    getIdeasActionableCount(),
+    getIdeasCounts(),
   ])
 
   const gatewayEntry = services.find(s => s.name === 'openclaw-gateway')
@@ -198,6 +200,6 @@ export async function getGlobalStatus() {
     failed_services: failedServices,
     ...vitals,
     ...usage,
-    ideas_actionable: ideasActionable,
+    ...ideasCounts,
   }
 }

--- a/src/components/approvals/ApprovalCard.tsx
+++ b/src/components/approvals/ApprovalCard.tsx
@@ -1,0 +1,180 @@
+import { useState } from 'react'
+import type { Idea, ApprovalAction } from '../../lib/types'
+
+interface ApprovalCardProps {
+  idea: Idea
+  onDecision: (id: string, action: ApprovalAction, reason?: string) => Promise<void>
+}
+
+function freshnessLabel(pendingSince: string | null | undefined): string {
+  if (!pendingSince) return 'unknown'
+  const mins = Math.floor((Date.now() - new Date(pendingSince).getTime()) / 60000)
+  if (mins < 1) return 'just now'
+  if (mins < 60) return `${mins}m ago`
+  const hours = Math.floor(mins / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  return `${days}d ago`
+}
+
+function freshnessColor(pendingSince: string | null | undefined): string {
+  if (!pendingSince) return 'text-text-tertiary'
+  const hours = (Date.now() - new Date(pendingSince).getTime()) / 3600000
+  if (hours < 1) return 'text-emerald'
+  if (hours < 24) return 'text-amber'
+  return 'text-red'
+}
+
+const ACTION_STYLES: Record<ApprovalAction, { label: string; classes: string; confirmLabel?: string }> = {
+  yes: {
+    label: 'Yes',
+    classes: 'bg-emerald-subtle text-emerald hover:brightness-110',
+  },
+  later: {
+    label: 'Later',
+    classes: 'bg-amber-subtle text-amber hover:brightness-110',
+  },
+  no: {
+    label: 'No',
+    classes: 'bg-red-subtle text-red hover:brightness-110',
+    confirmLabel: 'Archive this idea?',
+  },
+  rescope: {
+    label: 'Rescope',
+    classes: 'bg-blue-subtle text-blue hover:brightness-110',
+  },
+}
+
+export default function ApprovalCard({ idea, onDecision }: ApprovalCardProps) {
+  const [acting, setActing] = useState<ApprovalAction | null>(null)
+  const [confirming, setConfirming] = useState<ApprovalAction | null>(null)
+  const [reason, setReason] = useState('')
+
+  const handleAction = async (action: ApprovalAction) => {
+    // No/Rescope require confirmation
+    if ((action === 'no' || action === 'rescope') && confirming !== action) {
+      setConfirming(action)
+      return
+    }
+
+    setActing(action)
+    try {
+      await onDecision(idea.id, action, reason || undefined)
+    } finally {
+      setActing(null)
+      setConfirming(null)
+      setReason('')
+    }
+  }
+
+  const lastDecision = idea.approval_decisions?.length
+    ? idea.approval_decisions[idea.approval_decisions.length - 1]
+    : null
+
+  return (
+    <div className="bg-bg-surface border border-border-subtle rounded-md border-l-[3px] border-l-accent-purple">
+      <div className="p-3 space-y-2">
+        {/* Header: title + freshness */}
+        <div className="flex items-start justify-between gap-2">
+          <h3 className="text-sm font-medium text-text-primary truncate flex-1">
+            {idea.title}
+          </h3>
+          <span className={`text-[10px] shrink-0 ${freshnessColor(idea.pending_since)}`}>
+            {freshnessLabel(idea.pending_since)}
+          </span>
+        </div>
+
+        {/* Meta row: owner, route/outcome, id */}
+        <div className="flex flex-wrap items-center gap-2 text-[10px]">
+          <span className="px-1.5 py-0.5 rounded-sm bg-accent-purple-subtle text-accent-purple">
+            owner: platon
+          </span>
+          {idea.target_agent && (
+            <span className="px-1.5 py-0.5 rounded-sm bg-bg-overlay text-text-secondary">
+              agent: {idea.target_agent}
+            </span>
+          )}
+          <span className="text-text-tertiary font-mono">{idea.id}</span>
+        </div>
+
+        {/* Body / why approval is needed */}
+        {idea.body && (
+          <p className="text-xs text-text-secondary line-clamp-2">
+            {idea.body}
+          </p>
+        )}
+
+        {/* Artifact preview indicator */}
+        {idea.artifact_md && (
+          <p className="text-[10px] text-emerald">
+            Artifact ready ({Math.round(idea.artifact_md.length / 1024)}kb)
+          </p>
+        )}
+
+        {/* Previous decision note */}
+        {lastDecision && lastDecision.action === 'later' && (
+          <p className="text-[10px] text-amber bg-amber-subtle px-2 py-1 rounded-sm">
+            Deferred {freshnessLabel(lastDecision.timestamp)}
+            {lastDecision.reason && ` — ${lastDecision.reason}`}
+          </p>
+        )}
+
+        {/* Tags */}
+        {idea.tags?.length > 0 && (
+          <div className="flex flex-wrap gap-1">
+            {idea.tags.map((tag) => (
+              <span
+                key={tag}
+                className="text-[10px] px-1.5 py-0.5 rounded-sm bg-bg-overlay text-text-secondary"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        )}
+
+        {/* Confirmation row */}
+        {confirming && (
+          <div className="flex items-center gap-2 bg-bg-overlay rounded-sm p-2">
+            <input
+              type="text"
+              placeholder={confirming === 'rescope' ? 'Rescope reason…' : 'Reason (optional)…'}
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              className="flex-1 text-xs bg-transparent border-b border-border-subtle text-text-primary placeholder:text-text-tertiary outline-none py-0.5"
+            />
+            <button
+              onClick={() => handleAction(confirming)}
+              disabled={acting !== null}
+              className="text-[11px] px-2 py-1 rounded-sm bg-red-subtle text-red hover:brightness-110 disabled:opacity-50"
+            >
+              {acting === confirming ? 'Saving…' : 'Confirm'}
+            </button>
+            <button
+              onClick={() => { setConfirming(null); setReason('') }}
+              className="text-[11px] px-2 py-1 rounded-sm text-text-tertiary hover:text-text-primary"
+            >
+              Cancel
+            </button>
+          </div>
+        )}
+
+        {/* Action buttons */}
+        <div className="flex items-center gap-1.5">
+          {(Object.entries(ACTION_STYLES) as [ApprovalAction, typeof ACTION_STYLES[ApprovalAction]][]).map(
+            ([action, style]) => (
+              <button
+                key={action}
+                onClick={() => handleAction(action)}
+                disabled={acting !== null}
+                className={`text-[11px] px-3 py-1 rounded-sm transition-colors disabled:opacity-50 ${style.classes}`}
+              >
+                {acting === action ? 'Saving…' : style.label}
+              </button>
+            ),
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/ideas/IdeaCard.tsx
+++ b/src/components/ideas/IdeaCard.tsx
@@ -5,6 +5,7 @@ interface IdeaCardProps {
   idea: Idea
   onStatusChange: (id: string, status: IdeaStatus) => void
   onApprove: (id: string) => Promise<void>
+  onSubmitForApproval?: (id: string) => Promise<void>
   onArchive: (id: string) => void
 }
 
@@ -12,6 +13,7 @@ const STATUS_LABELS: Record<IdeaStatus, string> = {
   draft: 'Draft',
   brainstorming: 'Brainstorming',
   artifact_ready: 'Ready',
+  pending_approval: 'Pending Approval',
   approved: 'Approved',
   in_work: 'In Work',
   archived: 'Archived',
@@ -21,6 +23,7 @@ const STATUS_BADGE_CLASSES: Record<IdeaStatus, string> = {
   draft: 'bg-idea-draft text-text-secondary',
   brainstorming: 'bg-blue-subtle text-blue',
   artifact_ready: 'bg-emerald-subtle text-emerald',
+  pending_approval: 'bg-accent-purple-subtle text-accent-purple',
   approved: 'bg-accent-purple-subtle text-accent-purple',
   in_work: 'bg-amber-subtle text-amber',
   archived: 'bg-bg-overlay text-text-tertiary',
@@ -30,6 +33,7 @@ const BORDER_CLASSES: Record<IdeaStatus, string> = {
   draft: 'border-l-idea-draft',
   brainstorming: 'border-l-idea-brainstorming',
   artifact_ready: 'border-l-idea-artifact-ready',
+  pending_approval: 'border-l-accent-purple',
   approved: 'border-l-idea-approved',
   in_work: 'border-l-idea-in-work',
   archived: 'border-l-idea-archived',
@@ -42,7 +46,9 @@ function getNextActions(status: IdeaStatus): { label: string; next: IdeaStatus }
     case 'brainstorming':
       return [{ label: 'Mark Ready', next: 'artifact_ready' }]
     case 'artifact_ready':
-      return []  // Approve handled separately via onApprove
+      return []  // Submit for Approval handled separately via onSubmitForApproval
+    case 'pending_approval':
+      return []  // Decisions handled in Approvals page
     case 'approved':
       return []  // No manual "Start Work" — task creation handles this
     case 'in_work':
@@ -54,10 +60,11 @@ function getNextActions(status: IdeaStatus): { label: string; next: IdeaStatus }
   }
 }
 
-export default function IdeaCard({ idea, onStatusChange, onApprove, onArchive }: IdeaCardProps) {
+export default function IdeaCard({ idea, onStatusChange, onApprove, onSubmitForApproval, onArchive }: IdeaCardProps) {
   const status = idea.status && Object.prototype.hasOwnProperty.call(STATUS_LABELS, idea.status) ? idea.status : 'draft'
   const actions = getNextActions(status)
   const [approving, setApproving] = useState(false)
+  const [submittingApproval, setSubmittingApproval] = useState(false)
 
   const handleApprove = async () => {
     setApproving(true)
@@ -65,6 +72,16 @@ export default function IdeaCard({ idea, onStatusChange, onApprove, onArchive }:
       await onApprove(idea.id)
     } finally {
       setApproving(false)
+    }
+  }
+
+  const handleSubmitForApproval = async () => {
+    if (!onSubmitForApproval) return
+    setSubmittingApproval(true)
+    try {
+      await onSubmitForApproval(idea.id)
+    } finally {
+      setSubmittingApproval(false)
     }
   }
 
@@ -130,7 +147,16 @@ export default function IdeaCard({ idea, onStatusChange, onApprove, onArchive }:
               {action.label}
             </button>
           ))}
-          {status === 'artifact_ready' && (
+          {status === 'artifact_ready' && onSubmitForApproval && (
+            <button
+              onClick={handleSubmitForApproval}
+              disabled={submittingApproval}
+              className="text-[11px] px-2 py-1 rounded-sm bg-accent-purple-subtle text-accent-purple hover:brightness-110 transition-colors disabled:opacity-50"
+            >
+              {submittingApproval ? 'Submitting…' : 'Submit for Approval'}
+            </button>
+          )}
+          {status === 'artifact_ready' && !onSubmitForApproval && (
             <button
               onClick={handleApprove}
               disabled={approving}
@@ -138,6 +164,14 @@ export default function IdeaCard({ idea, onStatusChange, onApprove, onArchive }:
             >
               {approving ? 'Creating Task…' : 'Approve & Create Task'}
             </button>
+          )}
+          {status === 'pending_approval' && (
+            <a
+              href="/approvals"
+              className="text-[11px] px-2 py-1 rounded-sm bg-accent-purple-subtle text-accent-purple hover:brightness-110 transition-colors"
+            >
+              View in Approvals
+            </a>
           )}
           {status !== 'archived' && (
             <button

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -40,6 +40,16 @@ const navItems: NavItem[] = [
     badgeColor: 'amber',
   },
   {
+    to: '/approvals',
+    label: 'Approvals',
+    icon: '✋',
+    badge: (s) => {
+      if (!s) return null
+      return (s.approvals_pending ?? 0) > 0 ? s.approvals_pending : null
+    },
+    badgeColor: 'amber',
+  },
+  {
     to: '/agents',
     label: 'Agents',
     icon: '🤖',

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -14,6 +14,8 @@ import type {
   RateLimitsResponse,
   ThroughputStats,
   Idea,
+  ApprovalAction,
+  ApprovalDecision,
 } from './types';
 
 const BASE = '/api';
@@ -481,6 +483,23 @@ export function archiveIdea(id: string): Promise<{ ok: true }> {
 export function deleteIdea(id: string): Promise<Idea> {
   return request<Idea>(`/ideas/${encodeURIComponent(id)}`, {
     method: 'DELETE',
+  })
+}
+
+export function submitForApproval(id: string): Promise<Idea> {
+  return request<Idea>(`/ideas/${encodeURIComponent(id)}/submit-for-approval`, {
+    method: 'POST',
+  })
+}
+
+export function submitApprovalDecision(
+  id: string,
+  action: ApprovalAction,
+  reason?: string,
+): Promise<{ ok: true; idea: Idea; decision: ApprovalDecision }> {
+  return request(`/ideas/${encodeURIComponent(id)}/decision`, {
+    method: 'POST',
+    body: JSON.stringify({ action, reason }),
   })
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -14,6 +14,7 @@ export interface GlobalStatus {
   awaiting_owner_count: number
   awaiting_owner_overdue: boolean
   ideas_actionable: number
+  approvals_pending: number
   timestamp: string
 }
 
@@ -289,10 +290,20 @@ export interface ThroughputStats {
 // ─── Ideas ──────────────────────────────────────────────────────────────────
 
 export const IDEA_STATUSES = [
-  'draft', 'brainstorming', 'artifact_ready', 'approved', 'in_work', 'archived',
+  'draft', 'brainstorming', 'artifact_ready', 'pending_approval',
+  'approved', 'in_work', 'archived',
 ] as const;
 
 export type IdeaStatus = (typeof IDEA_STATUSES)[number];
+
+export type ApprovalAction = 'yes' | 'later' | 'no' | 'rescope';
+
+export interface ApprovalDecision {
+  action: ApprovalAction;
+  actor: string;
+  timestamp: string;
+  reason?: string;
+}
 
 export interface Idea {
   id: string;
@@ -307,6 +318,8 @@ export interface Idea {
   artifact_generated_at?: string | null;
   task_id?: string | null;
   brainstorm_session_id?: string | null;
+  pending_since?: string | null;
+  approval_decisions?: ApprovalDecision[];
   created_at: string;
   updated_at: string;
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,6 +8,7 @@ import SystemPage from './pages/SystemPage'
 import LogsPage from './pages/LogsPage'
 import ConfigPage from './pages/ConfigPage'
 import IdeasPage from './pages/IdeasPage'
+import ApprovalsPage from './pages/ApprovalsPage'
 import { ToastProvider } from './hooks/useToast'
 import ErrorBoundary from './components/layout/ErrorBoundary'
 import ToastStack from './components/layout/Toast'
@@ -21,6 +22,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
           <Route element={<App />}>
             <Route index element={<ErrorBoundary><PipelinePage /></ErrorBoundary>} />
             <Route path="ideas" element={<ErrorBoundary><IdeasPage /></ErrorBoundary>} />
+            <Route path="approvals" element={<ErrorBoundary><ApprovalsPage /></ErrorBoundary>} />
             <Route path="agents" element={<ErrorBoundary><AgentsPage /></ErrorBoundary>} />
             <Route path="system" element={<ErrorBoundary><SystemPage /></ErrorBoundary>} />
             <Route path="logs" element={<ErrorBoundary><LogsPage /></ErrorBoundary>} />

--- a/src/pages/ApprovalsPage.tsx
+++ b/src/pages/ApprovalsPage.tsx
@@ -1,0 +1,110 @@
+import { useCallback } from 'react'
+import { usePolling } from '../hooks/usePolling'
+import { useToast } from '../hooks/useToast'
+import { fetchIdeas, submitApprovalDecision, createTask, approveIdea } from '../lib/api'
+import type { Idea, ApprovalAction } from '../lib/types'
+import ApprovalCard from '../components/approvals/ApprovalCard'
+import EmptyState from '../components/ui/EmptyState'
+
+export default function ApprovalsPage() {
+  const { push } = useToast()
+
+  const fetcher = useCallback(() => fetchIdeas('pending_approval'), [])
+  const { data: ideas, loading, error, refetch } = usePolling(fetcher, 5000)
+
+  const handleDecision = async (id: string, action: ApprovalAction, reason?: string) => {
+    try {
+      const result = await submitApprovalDecision(id, action, reason)
+
+      if (action === 'yes') {
+        // On approval, create task and wire it to the idea
+        const idea = result.idea
+        try {
+          const { task_id } = await createTask({
+            title: idea.title,
+            route: 'artifact_route',
+            outcome_type: 'strategy_doc',
+          })
+          await approveIdea(id, task_id)
+          push({
+            message: `Approved — task ${task_id} created`,
+            variant: 'success',
+            action: { label: 'Open Pipeline', fn: () => { window.location.href = `/pipeline?task=${task_id}` } },
+          })
+        } catch (routeErr) {
+          push({
+            message: `Approved but task routing failed: ${routeErr instanceof Error ? routeErr.message : 'unknown error'}`,
+            variant: 'warning',
+          })
+        }
+      } else if (action === 'later') {
+        push({ message: 'Deferred — will revisit later', variant: 'warning' })
+      } else if (action === 'no') {
+        push({ message: 'Rejected and archived', variant: 'success' })
+      } else if (action === 'rescope') {
+        push({ message: 'Sent back to draft for rescoping', variant: 'success' })
+      }
+
+      await refetch()
+    } catch (err: unknown) {
+      const errObj = err as Record<string, string> | Error
+      if ('error' in errObj && (errObj as Record<string, string>).error === 'STALE_STATE') {
+        push({
+          message: (errObj as Record<string, string>).message || 'Item already resolved elsewhere',
+          variant: 'warning',
+        })
+        await refetch()
+      } else {
+        push({
+          message: err instanceof Error ? err.message : 'Decision failed',
+          variant: 'error',
+        })
+      }
+    }
+  }
+
+  const queue: Idea[] = ideas ?? []
+
+  return (
+    <div className="min-h-full space-y-4">
+      {/* Header */}
+      <div className="flex items-center gap-2">
+        <h1 className="text-lg font-semibold text-text-primary">Approvals</h1>
+        {queue.length > 0 && (
+          <span className="text-[10px] font-bold bg-accent-purple text-text-inverse rounded-full min-w-[18px] h-[18px] flex items-center justify-center px-1">
+            {queue.length}
+          </span>
+        )}
+      </div>
+
+      {/* Error state */}
+      {error && (
+        <div className="p-3 bg-red-subtle border border-red rounded-md text-sm text-red">
+          Failed to load approvals: {error.message}
+          <button onClick={refetch} className="ml-2 underline">Retry</button>
+        </div>
+      )}
+
+      {/* Loading state */}
+      {loading && !ideas ? (
+        <div className="space-y-3">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-28 bg-bg-surface border border-border-subtle rounded-md animate-skeleton" />
+          ))}
+        </div>
+      ) : queue.length === 0 ? (
+        <EmptyState
+          icon="✓"
+          title="No items pending approval"
+          description="Ideas that need your decision will appear here"
+        />
+      ) : (
+        <div className="space-y-3">
+          {queue.map((idea) => (
+            <ApprovalCard key={idea.id} idea={idea} onDecision={handleDecision} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/pages/IdeasPage.tsx
+++ b/src/pages/IdeasPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback } from 'react'
 import { usePolling } from '../hooks/usePolling'
 import { useToast } from '../hooks/useToast'
-import { fetchIdeas, createIdea, updateIdea, deleteIdea, createTask, approveIdea } from '../lib/api'
+import { fetchIdeas, createIdea, updateIdea, deleteIdea, createTask, approveIdea, submitForApproval } from '../lib/api'
 import type { IdeaStatus } from '../lib/types'
 import IdeaCard from '../components/ideas/IdeaCard'
 import IdeaForm from '../components/ideas/IdeaForm'
@@ -12,6 +12,7 @@ const FILTER_TABS: { label: string; value: IdeaStatus | 'all' }[] = [
   { label: 'Draft', value: 'draft' },
   { label: 'Brainstorming', value: 'brainstorming' },
   { label: 'Ready', value: 'artifact_ready' },
+  { label: 'Pending', value: 'pending_approval' },
   { label: 'In Work', value: 'in_work' },
   { label: 'Archived', value: 'archived' },
 ]
@@ -73,6 +74,16 @@ export default function IdeasPage() {
       await refetch()
     } catch (err) {
       push({ message: err instanceof Error ? err.message : 'Failed to approve idea', variant: 'error' })
+    }
+  }
+
+  const handleSubmitForApproval = async (id: string) => {
+    try {
+      await submitForApproval(id)
+      push({ message: 'Submitted for approval', variant: 'success' })
+      await refetch()
+    } catch (err) {
+      push({ message: err instanceof Error ? err.message : 'Failed to submit for approval', variant: 'error' })
     }
   }
 
@@ -168,6 +179,7 @@ export default function IdeasPage() {
               idea={idea}
               onStatusChange={handleStatusChange}
               onApprove={handleApprove}
+              onSubmitForApproval={handleSubmitForApproval}
               onArchive={handleArchive}
             />
           ))}

--- a/tests/client/approval-queue.test.tsx
+++ b/tests/client/approval-queue.test.tsx
@@ -1,0 +1,292 @@
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { Idea } from '../../src/lib/types'
+
+// Mock API
+vi.mock('../../src/lib/api', () => ({
+  fetchIdeas: vi.fn(),
+  submitApprovalDecision: vi.fn(),
+  createTask: vi.fn(),
+  approveIdea: vi.fn(),
+}))
+
+// Mock usePolling
+vi.mock('../../src/hooks/usePolling', () => ({
+  usePolling: vi.fn(),
+}))
+
+// Mock useToast
+const mockPush = vi.fn()
+vi.mock('../../src/hooks/useToast', () => ({
+  useToast: vi.fn(() => ({ push: mockPush })),
+}))
+
+import ApprovalsPage from '../../src/pages/ApprovalsPage'
+import ApprovalCard from '../../src/components/approvals/ApprovalCard'
+import { submitApprovalDecision, createTask, approveIdea } from '../../src/lib/api'
+import { usePolling } from '../../src/hooks/usePolling'
+
+function makeIdea(overrides: Partial<Idea> = {}): Idea {
+  return {
+    id: 'idea_20260401_abc123',
+    title: 'Test approval idea',
+    body: 'This idea needs your decision',
+    status: 'pending_approval',
+    tags: ['feature'],
+    target_agent: 'brainstorm-claude',
+    pending_since: '2026-04-01T10:00:00Z',
+    approval_decisions: [],
+    created_at: '2026-03-31T00:00:00Z',
+    updated_at: '2026-04-01T10:00:00Z',
+    ...overrides,
+  }
+}
+
+describe('Approval Queue', () => {
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  describe('ApprovalsPage', () => {
+    const mockRefetch = vi.fn().mockResolvedValue(undefined)
+
+    it('renders empty state when no pending approvals', () => {
+      (usePolling as ReturnType<typeof vi.fn>).mockReturnValue({
+        data: [],
+        loading: false,
+        error: null,
+        refetch: mockRefetch,
+      })
+
+      render(<ApprovalsPage />)
+      expect(screen.getByText('No items pending approval')).toBeTruthy()
+    })
+
+    it('renders loading skeletons while loading', () => {
+      (usePolling as ReturnType<typeof vi.fn>).mockReturnValue({
+        data: null,
+        loading: true,
+        error: null,
+        refetch: mockRefetch,
+      })
+
+      render(<ApprovalsPage />)
+      // Should show skeleton divs with animate-skeleton class
+      const skeletons = document.querySelectorAll('.animate-skeleton')
+      expect(skeletons.length).toBe(3)
+    })
+
+    it('renders error state with retry', () => {
+      (usePolling as ReturnType<typeof vi.fn>).mockReturnValue({
+        data: null,
+        loading: false,
+        error: new Error('Network failure'),
+        refetch: mockRefetch,
+      })
+
+      render(<ApprovalsPage />)
+      expect(screen.getByText(/Network failure/)).toBeTruthy()
+      expect(screen.getByText('Retry')).toBeTruthy()
+    })
+
+    it('renders approval cards for pending items', () => {
+      (usePolling as ReturnType<typeof vi.fn>).mockReturnValue({
+        data: [makeIdea(), makeIdea({ id: 'idea_20260401_def456', title: 'Second idea' })],
+        loading: false,
+        error: null,
+        refetch: mockRefetch,
+      })
+
+      render(<ApprovalsPage />)
+      expect(screen.getByText('Test approval idea')).toBeTruthy()
+      expect(screen.getByText('Second idea')).toBeTruthy()
+    })
+
+    it('shows badge count in header', () => {
+      (usePolling as ReturnType<typeof vi.fn>).mockReturnValue({
+        data: [makeIdea(), makeIdea({ id: 'idea_20260401_def456' })],
+        loading: false,
+        error: null,
+        refetch: mockRefetch,
+      })
+
+      render(<ApprovalsPage />)
+      expect(screen.getByText('2')).toBeTruthy()
+    })
+
+    it('Yes action: submits decision, creates task, shows success toast', async () => {
+      (usePolling as ReturnType<typeof vi.fn>).mockReturnValue({
+        data: [makeIdea()],
+        loading: false,
+        error: null,
+        refetch: mockRefetch,
+      });
+      (submitApprovalDecision as ReturnType<typeof vi.fn>).mockResolvedValue({
+        ok: true,
+        idea: { ...makeIdea(), status: 'approved' },
+        decision: { action: 'yes', actor: 'platon', timestamp: '2026-04-01T12:00:00Z' },
+      });
+      (createTask as ReturnType<typeof vi.fn>).mockResolvedValue({ task_id: 'tsk_001' });
+      (approveIdea as ReturnType<typeof vi.fn>).mockResolvedValue({})
+
+      render(<ApprovalsPage />)
+      fireEvent.click(screen.getByText('Yes'))
+
+      await waitFor(() => {
+        expect(submitApprovalDecision).toHaveBeenCalledWith('idea_20260401_abc123', 'yes', undefined)
+        expect(createTask).toHaveBeenCalledWith({
+          title: 'Test approval idea',
+          route: 'artifact_route',
+          outcome_type: 'strategy_doc',
+        })
+        expect(approveIdea).toHaveBeenCalledWith('idea_20260401_abc123', 'tsk_001')
+        expect(mockPush).toHaveBeenCalledWith(
+          expect.objectContaining({ message: expect.stringContaining('tsk_001'), variant: 'success' })
+        )
+      })
+    })
+
+    it('Later action: submits decision, shows warning toast', async () => {
+      (usePolling as ReturnType<typeof vi.fn>).mockReturnValue({
+        data: [makeIdea()],
+        loading: false,
+        error: null,
+        refetch: mockRefetch,
+      });
+      (submitApprovalDecision as ReturnType<typeof vi.fn>).mockResolvedValue({
+        ok: true,
+        idea: makeIdea(),
+        decision: { action: 'later', actor: 'platon', timestamp: '2026-04-01T12:00:00Z' },
+      })
+
+      render(<ApprovalsPage />)
+      fireEvent.click(screen.getByText('Later'))
+
+      await waitFor(() => {
+        expect(submitApprovalDecision).toHaveBeenCalledWith('idea_20260401_abc123', 'later', undefined)
+        expect(mockPush).toHaveBeenCalledWith(
+          expect.objectContaining({ variant: 'warning' })
+        )
+      })
+    })
+
+    it('stale state error: shows warning and refetches', async () => {
+      (usePolling as ReturnType<typeof vi.fn>).mockReturnValue({
+        data: [makeIdea()],
+        loading: false,
+        error: null,
+        refetch: mockRefetch,
+      });
+      (submitApprovalDecision as ReturnType<typeof vi.fn>).mockRejectedValue({
+        error: 'STALE_STATE',
+        message: 'Item already resolved elsewhere',
+        current_status: 'approved',
+      })
+
+      render(<ApprovalsPage />)
+      fireEvent.click(screen.getByText('Later'))
+
+      await waitFor(() => {
+        expect(mockPush).toHaveBeenCalledWith(
+          expect.objectContaining({ variant: 'warning', message: expect.stringContaining('resolved') })
+        )
+        expect(mockRefetch).toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('ApprovalCard', () => {
+    const mockOnDecision = vi.fn().mockResolvedValue(undefined)
+
+    it('renders idea title, body, and meta', () => {
+      render(<ApprovalCard idea={makeIdea()} onDecision={mockOnDecision} />)
+      expect(screen.getByText('Test approval idea')).toBeTruthy()
+      expect(screen.getByText('This idea needs your decision')).toBeTruthy()
+      expect(screen.getByText('owner: platon')).toBeTruthy()
+      expect(screen.getByText('idea_20260401_abc123')).toBeTruthy()
+    })
+
+    it('renders all 4 action buttons', () => {
+      render(<ApprovalCard idea={makeIdea()} onDecision={mockOnDecision} />)
+      expect(screen.getByText('Yes')).toBeTruthy()
+      expect(screen.getByText('Later')).toBeTruthy()
+      expect(screen.getByText('No')).toBeTruthy()
+      expect(screen.getByText('Rescope')).toBeTruthy()
+    })
+
+    it('Yes button calls onDecision directly', async () => {
+      render(<ApprovalCard idea={makeIdea()} onDecision={mockOnDecision} />)
+      fireEvent.click(screen.getByText('Yes'))
+
+      await waitFor(() => {
+        expect(mockOnDecision).toHaveBeenCalledWith('idea_20260401_abc123', 'yes', undefined)
+      })
+    })
+
+    it('Later button calls onDecision directly', async () => {
+      render(<ApprovalCard idea={makeIdea()} onDecision={mockOnDecision} />)
+      fireEvent.click(screen.getByText('Later'))
+
+      await waitFor(() => {
+        expect(mockOnDecision).toHaveBeenCalledWith('idea_20260401_abc123', 'later', undefined)
+      })
+    })
+
+    it('No button requires confirmation', () => {
+      render(<ApprovalCard idea={makeIdea()} onDecision={mockOnDecision} />)
+      fireEvent.click(screen.getByText('No'))
+      // Should show confirmation UI, not call onDecision yet
+      expect(mockOnDecision).not.toHaveBeenCalled()
+      expect(screen.getByText('Confirm')).toBeTruthy()
+    })
+
+    it('Rescope button requires confirmation', () => {
+      render(<ApprovalCard idea={makeIdea()} onDecision={mockOnDecision} />)
+      fireEvent.click(screen.getByText('Rescope'))
+      expect(mockOnDecision).not.toHaveBeenCalled()
+      expect(screen.getByText('Confirm')).toBeTruthy()
+    })
+
+    it('No → Confirm calls onDecision with no action', async () => {
+      render(<ApprovalCard idea={makeIdea()} onDecision={mockOnDecision} />)
+      fireEvent.click(screen.getByText('No'))
+      fireEvent.click(screen.getByText('Confirm'))
+
+      await waitFor(() => {
+        expect(mockOnDecision).toHaveBeenCalledWith('idea_20260401_abc123', 'no', undefined)
+      })
+    })
+
+    it('shows tags', () => {
+      render(<ApprovalCard idea={makeIdea({ tags: ['infra', 'urgent'] })} onDecision={mockOnDecision} />)
+      expect(screen.getByText('infra')).toBeTruthy()
+      expect(screen.getByText('urgent')).toBeTruthy()
+    })
+
+    it('shows deferred note when last decision was later', () => {
+      const idea = makeIdea({
+        approval_decisions: [
+          { action: 'later', actor: 'platon', timestamp: '2026-04-01T08:00:00Z', reason: 'Need more context' },
+        ],
+      })
+      render(<ApprovalCard idea={idea} onDecision={mockOnDecision} />)
+      expect(screen.getByText(/Need more context/)).toBeTruthy()
+    })
+
+    it('shows freshness indicator', () => {
+      render(<ApprovalCard idea={makeIdea()} onDecision={mockOnDecision} />)
+      // Should render some freshness text (exact value depends on current time)
+      const card = document.querySelector('.border-l-accent-purple')
+      expect(card).toBeTruthy()
+    })
+
+    it('cancel confirmation returns to normal state', () => {
+      render(<ApprovalCard idea={makeIdea()} onDecision={mockOnDecision} />)
+      fireEvent.click(screen.getByText('No'))
+      expect(screen.getByText('Confirm')).toBeTruthy()
+      fireEvent.click(screen.getByText('Cancel'))
+      expect(screen.queryByText('Confirm')).toBeNull()
+    })
+  })
+})

--- a/tests/client/idea-approve.test.tsx
+++ b/tests/client/idea-approve.test.tsx
@@ -10,6 +10,7 @@ vi.mock('../../src/lib/api', () => ({
   deleteIdea: vi.fn(),
   createTask: vi.fn(),
   approveIdea: vi.fn(),
+  submitForApproval: vi.fn(),
 }))
 
 // Mock usePolling
@@ -25,7 +26,7 @@ vi.mock('../../src/hooks/useToast', () => ({
 
 import IdeasPage from '../../src/pages/IdeasPage'
 import IdeaCard from '../../src/components/ideas/IdeaCard'
-import { createTask, approveIdea } from '../../src/lib/api'
+import { createTask, approveIdea, submitForApproval } from '../../src/lib/api'
 import { usePolling } from '../../src/hooks/usePolling'
 
 function makeIdea(overrides: Partial<Idea> = {}): Idea {
@@ -59,37 +60,30 @@ describe('Ideas approve & create task', () => {
       })
     })
 
-    it('approve success: createTask called, then approveIdea with task_id, then success toast', async () => {
-      (createTask as ReturnType<typeof vi.fn>).mockResolvedValue({ task_id: 'tsk_abc' });
-      (approveIdea as ReturnType<typeof vi.fn>).mockResolvedValue({});
+    it('submit for approval success: calls submitForApproval and shows success toast', async () => {
+      (submitForApproval as ReturnType<typeof vi.fn>).mockResolvedValue({});
 
       render(<IdeasPage />)
 
-      fireEvent.click(screen.getByText('Approve & Create Task'))
+      fireEvent.click(screen.getByText('Submit for Approval'))
 
       await waitFor(() => {
-        expect(createTask).toHaveBeenCalledWith({
-          title: 'Test idea',
-          route: 'artifact_route',
-          outcome_type: 'strategy_doc',
-        })
-        expect(approveIdea).toHaveBeenCalledWith('idea_001', 'tsk_abc')
+        expect(submitForApproval).toHaveBeenCalledWith('idea_001')
         expect(mockPush).toHaveBeenCalledWith(
-          expect.objectContaining({ message: 'Task created: tsk_abc', variant: 'success' })
+          expect.objectContaining({ message: 'Submitted for approval', variant: 'success' })
         )
       })
     })
 
-    it('createTask fails: approveIdea NOT called, error toast shown', async () => {
-      (createTask as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('Network error'));
+    it('submit for approval fails: error toast shown', async () => {
+      (submitForApproval as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('Network error'));
 
       render(<IdeasPage />)
 
-      fireEvent.click(screen.getByText('Approve & Create Task'))
+      fireEvent.click(screen.getByText('Submit for Approval'))
 
       await waitFor(() => {
-        expect(createTask).toHaveBeenCalled()
-        expect(approveIdea).not.toHaveBeenCalled()
+        expect(submitForApproval).toHaveBeenCalled()
         expect(mockPush).toHaveBeenCalledWith(
           expect.objectContaining({ message: 'Network error', variant: 'error' })
         )

--- a/tests/server/approval-decision.test.ts
+++ b/tests/server/approval-decision.test.ts
@@ -1,0 +1,186 @@
+// @vitest-environment node
+import express from 'express'
+import request from 'supertest'
+import { describe, expect, it, beforeAll, afterAll, beforeEach } from 'vitest'
+import { mkdtemp, rm, writeFile } from 'fs/promises'
+import { mkdirSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+let app: express.Express
+let tempDir: string
+let originalHome: string
+let ideasDir: string
+
+beforeAll(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), 'approval-test-'))
+  ideasDir = join(tempDir, 'clawd', 'ideas')
+  mkdirSync(ideasDir, { recursive: true })
+
+  originalHome = process.env.HOME!
+  process.env.HOME = tempDir
+
+  const { default: ideasRouter } = await import('../../server/api/ideas.js')
+
+  app = express()
+  app.use(express.json())
+  app.use('/api/ideas', ideasRouter)
+})
+
+afterAll(async () => {
+  process.env.HOME = originalHome
+  await rm(tempDir, { recursive: true, force: true })
+})
+
+function writeIdea(id: string, overrides: Record<string, unknown> = {}) {
+  const idea = {
+    id,
+    title: 'Test idea',
+    body: 'Body text',
+    status: 'pending_approval',
+    tags: [],
+    target_agent: 'brainstorm-claude',
+    pending_since: '2026-04-01T10:00:00Z',
+    approval_decisions: [],
+    created_at: '2026-03-31T00:00:00Z',
+    updated_at: '2026-04-01T10:00:00Z',
+    ...overrides,
+  }
+  return writeFile(join(ideasDir, `${id}.json`), JSON.stringify(idea, null, 2))
+}
+
+describe('POST /api/ideas/:id/decision', () => {
+  beforeEach(async () => {
+    await writeIdea('idea_20260401_aaa111')
+  })
+
+  it('yes: transitions to approved and records decision', async () => {
+    const res = await request(app)
+      .post('/api/ideas/idea_20260401_aaa111/decision')
+      .send({ action: 'yes' })
+    expect(res.status).toBe(200)
+    expect(res.body.ok).toBe(true)
+    expect(res.body.idea.status).toBe('approved')
+    expect(res.body.decision.action).toBe('yes')
+    expect(res.body.decision.actor).toBe('platon')
+    expect(res.body.idea.approval_decisions).toHaveLength(1)
+  })
+
+  it('later: stays pending_approval and records decision', async () => {
+    const res = await request(app)
+      .post('/api/ideas/idea_20260401_aaa111/decision')
+      .send({ action: 'later', reason: 'Need more info' })
+    expect(res.status).toBe(200)
+    expect(res.body.idea.status).toBe('pending_approval')
+    expect(res.body.decision.action).toBe('later')
+    expect(res.body.decision.reason).toBe('Need more info')
+  })
+
+  it('no: transitions to archived', async () => {
+    const res = await request(app)
+      .post('/api/ideas/idea_20260401_aaa111/decision')
+      .send({ action: 'no', reason: 'Not aligned with goals' })
+    expect(res.status).toBe(200)
+    expect(res.body.idea.status).toBe('archived')
+    expect(res.body.decision.action).toBe('no')
+    expect(res.body.decision.reason).toBe('Not aligned with goals')
+  })
+
+  it('rescope: transitions back to draft and clears pending_since', async () => {
+    const res = await request(app)
+      .post('/api/ideas/idea_20260401_aaa111/decision')
+      .send({ action: 'rescope', reason: 'Needs narrower scope' })
+    expect(res.status).toBe(200)
+    expect(res.body.idea.status).toBe('draft')
+    expect(res.body.idea.pending_since).toBeNull()
+    expect(res.body.decision.action).toBe('rescope')
+  })
+
+  it('rejects invalid action', async () => {
+    const res = await request(app)
+      .post('/api/ideas/idea_20260401_aaa111/decision')
+      .send({ action: 'maybe' })
+    expect(res.status).toBe(400)
+    expect(res.body.error).toMatch(/Invalid action/)
+  })
+
+  it('rejects decision on non-pending idea (stale state)', async () => {
+    await writeIdea('idea_20260401_bbb222', { status: 'approved' })
+    const res = await request(app)
+      .post('/api/ideas/idea_20260401_bbb222/decision')
+      .send({ action: 'yes' })
+    expect(res.status).toBe(409)
+    expect(res.body.error).toBe('STALE_STATE')
+    expect(res.body.current_status).toBe('approved')
+  })
+
+  it('returns 404 for non-existent idea', async () => {
+    const res = await request(app)
+      .post('/api/ideas/idea_20260401_aaa999/decision')
+      .send({ action: 'yes' })
+    expect(res.status).toBe(404)
+    expect(res.body.error).toBe('idea not found')
+  })
+
+  it('accumulates multiple decisions on same idea', async () => {
+    // First: later
+    await request(app)
+      .post('/api/ideas/idea_20260401_aaa111/decision')
+      .send({ action: 'later', reason: 'First pass' })
+
+    // Second: yes (still pending_approval after later)
+    const res = await request(app)
+      .post('/api/ideas/idea_20260401_aaa111/decision')
+      .send({ action: 'yes' })
+    expect(res.status).toBe(200)
+    expect(res.body.idea.approval_decisions).toHaveLength(2)
+    expect(res.body.idea.approval_decisions[0].action).toBe('later')
+    expect(res.body.idea.approval_decisions[1].action).toBe('yes')
+  })
+
+  it('rejects invalid id format', async () => {
+    const res = await request(app)
+      .post('/api/ideas/invalid-id-format/decision')
+      .send({ action: 'yes' })
+    expect(res.status).toBe(400)
+    expect(res.body.error).toMatch(/Invalid idea id/)
+  })
+})
+
+describe('POST /api/ideas/:id/submit-for-approval', () => {
+  it('transitions artifact_ready to pending_approval', async () => {
+    await writeIdea('idea_20260401_ccc333', {
+      status: 'artifact_ready',
+      pending_since: null,
+    })
+    const res = await request(app)
+      .post('/api/ideas/idea_20260401_ccc333/submit-for-approval')
+      .send()
+    expect(res.status).toBe(200)
+    expect(res.body.status).toBe('pending_approval')
+    expect(res.body.pending_since).toBeTruthy()
+  })
+
+  it('rejects non-artifact_ready ideas', async () => {
+    await writeIdea('idea_20260401_ddd444', { status: 'draft' })
+    const res = await request(app)
+      .post('/api/ideas/idea_20260401_ddd444/submit-for-approval')
+      .send()
+    expect(res.status).toBe(400)
+    expect(res.body.error).toMatch(/Cannot submit for approval/)
+  })
+})
+
+describe('GET /api/ideas?status=pending_approval', () => {
+  it('filters to only pending_approval ideas', async () => {
+    await writeIdea('idea_20260401_eee555', { status: 'pending_approval' })
+    await writeIdea('idea_20260401_fff666', { status: 'draft' })
+
+    const res = await request(app)
+      .get('/api/ideas?status=pending_approval')
+    expect(res.status).toBe(200)
+    const ids = res.body.map((i: { id: string }) => i.id)
+    expect(ids).toContain('idea_20260401_eee555')
+    expect(ids).not.toContain('idea_20260401_fff666')
+  })
+})


### PR DESCRIPTION
## Summary
Closes #164

- Adds `pending_approval` as a new `IdeaStatus` with full lifecycle: ideas go from `artifact_ready` → `pending_approval` → decision (yes/later/no/rescope)
- New `POST /api/ideas/:id/decision` endpoint persists approval decisions durably with STALE_STATE conflict detection for items resolved elsewhere
- New `POST /api/ideas/:id/submit-for-approval` endpoint transitions artifact_ready → pending_approval
- **ApprovalCard** component: compact decision cards showing idea title, body, owner (platon), freshness indicator, tags, artifact preview, deferred-decision notes, and 4 action buttons (Yes/Later/No/Rescope) with confirmation flow for destructive actions
- **ApprovalsPage**: dedicated queue at `/approvals` with empty, loading, and error states; badge count in sidebar
- On **Yes**: submits decision → creates task → wires task_id to idea → shows pipeline link (handles routing failure gracefully)
- On **Later**: stays in queue with deferred note visible on next visit
- On **No**: archives idea with reason
- On **Rescope**: returns to draft for rework
- Updated `GlobalStatus` to include `approvals_pending` count for sidebar badge
- Updated IdeaCard to show "Submit for Approval" on artifact_ready and "View in Approvals" on pending_approval

## Files changed (13)
- `src/lib/types.ts` — added `pending_approval`, `ApprovalAction`, `ApprovalDecision` types, `approvals_pending` to GlobalStatus
- `src/lib/api.ts` — added `submitForApproval()`, `submitApprovalDecision()` API functions
- `server/api/ideas.js` — added `decision` and `submit-for-approval` endpoints, `pending_approval` to valid statuses
- `server/lib/status.js` — added `approvals_pending` count to global status
- `src/components/approvals/ApprovalCard.tsx` — new compact decision card component
- `src/pages/ApprovalsPage.tsx` — new approval queue page
- `src/main.tsx` — added `/approvals` route
- `src/components/layout/Sidebar.tsx` — added Approvals nav with badge
- `src/components/ideas/IdeaCard.tsx` — updated for `pending_approval` status
- `src/pages/IdeasPage.tsx` — added submit-for-approval handler and filter tab
- `tests/client/approval-queue.test.tsx` — 19 new client tests
- `tests/server/approval-decision.test.ts` — 12 new server tests
- `tests/client/idea-approve.test.tsx` — updated for new flow

## Test plan
- [x] 31 new tests pass (19 client, 12 server)
- [x] All 432 existing tests pass (54 test files)
- [x] Vite production build succeeds
- [ ] Manual: create idea → brainstorm → artifact_ready → Submit for Approval → verify appears in /approvals
- [ ] Manual: test Yes/Later/No/Rescope flows on decision cards
- [ ] Manual: verify stale-state handling (resolve idea elsewhere, then try to decide)
- [ ] Manual: verify sidebar badge count updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)